### PR TITLE
Removed logging for remote address (Fix Kodi crash on start)

### DIFF
--- a/resources/lib/helper/loghandler.py
+++ b/resources/lib/helper/loghandler.py
@@ -36,9 +36,6 @@ class LogHandler(logging.StreamHandler):
             if server.get('LocalAddress'):
                 self.sensitive['Server'].append(server['LocalAddress'].split('://')[1])
 
-            if server.get('RemoteAddress'):
-                self.sensitive['Server'].append(server['RemoteAddress'].split('://')[1])
-
             if server.get('ManualAddress'):
                 self.sensitive['Server'].append(server['ManualAddress'].split('://')[1])
 


### PR DESCRIPTION
If the Emby add-on is installed on a fresh installation of Kodi and pointed to a Jellyfin instance, the plugin will immediately and irrecoverably crash, as seen below:

```
07:38:21.119 T:123145527160832   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.IndexError'>
                                            Error Contents: list index out of range
                                            Traceback (most recent call last):
                                              File "/Users/jonwest/Library/Application Support/Kodi/addons/plugin.video.emby/service.py", line 31, in <module>
                                                from entrypoint import Service
                                              File "/Users/jonwest/Library/Application Support/Kodi/addons/plugin.video.emby/resources/lib/entrypoint/__init__.py", line 15, in <module>
                                                Emby.set_loghandler(loghandler.LogHandler, logging.DEBUG)
                                              File "/Users/jonwest/Library/Application Support/Kodi/addons/plugin.video.emby/resources/lib/emby/__init__.py", line 68, in set_loghandler
                                                config(level)
                                              File "/Users/jonwest/Library/Application Support/Kodi/addons/plugin.video.emby/resources/lib/emby/__init__.py", line 24, in config
                                                logger.addHandler(Emby.loghandler())
                                              File "/Users/jonwest/Library/Application Support/Kodi/addons/plugin.video.emby/resources/lib/helper/loghandler.py", line 40, in __init__
                                                self.sensitive['Server'].append(server['RemoteAddress'].split('://')[1])
                                            IndexError: list index out of range
                                            -->End of Python script error report<--
```

Given that Jellyfin does not use the RemoteAddress (as it is my understanding this is for calling back to EmbyConnect?), I've removed this portion from the file, and the plugin performs as expected.