### PR TITLE
Always use plaintext login

### DIFF
--- a/resources/lib/dialogs/loginmanual.py
+++ b/resources/lib/dialogs/loginmanual.py
@@ -120,7 +120,7 @@ class LoginManual(xbmcgui.WindowXMLDialog):
 
         mode = self.connect_manager['server-mode']
         server = self.connect_manager['server-address']
-        result = self.connect_manager['login'](server, username, password, False if mode == 1 and server.startswith('http://') else True)
+        result = self.connect_manager['login'](server, username, password)
 
         if not result:
             self._error(ERROR['Invalid'], _('invalid_auth'))

--- a/resources/lib/jellyfin/core/connection_manager.py
+++ b/resources/lib/jellyfin/core/connection_manager.py
@@ -157,12 +157,10 @@ class ConnectionManager(object):
                 'type': "POST",
                 'url': self.get_jellyfin_url(server, "Users/AuthenticateByName"),
                 'json': {
-                    'username': username,
-                    'password': hashlib.sha1(password or "").hexdigest(),
+                    'Username': username,
+                    'Pw': password or ""
                 }
             }
-            if clear:
-                request['json']['pw'] = password or ""
 
             result = self._request_url(request, False)
         except Exception as error: # Failed to login


### PR DESCRIPTION
Fixes #22

This means plaintext passwords now can travel over the internet over http.
You should protect your servers accordingly with https.