### PR TITLE
Make sure __base__ is the first place we look for packages.

### DIFF
--- a/context.py
+++ b/context.py
@@ -16,7 +16,7 @@ __base__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'reso
 __libraries__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'libraries')).decode('utf-8')
 
 sys.path.insert(0, __libraries__)
-sys.path.append(__base__)
+sys.path.insert(0, __base__)
 
 #################################################################################################
 

--- a/context_play.py
+++ b/context_play.py
@@ -16,7 +16,7 @@ __base__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'reso
 __libraries__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'libraries')).decode('utf-8')
 
 sys.path.insert(0, __libraries__)
-sys.path.append(__base__)
+sys.path.insert(0, __base__)
 
 #################################################################################################
 

--- a/default.py
+++ b/default.py
@@ -16,7 +16,7 @@ __base__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'reso
 __libraries__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'libraries')).decode('utf-8')
 
 sys.path.insert(0, __libraries__)
-sys.path.append(__base__)
+sys.path.insert(0, __base__)
 
 #################################################################################################
 

--- a/service.py
+++ b/service.py
@@ -17,7 +17,7 @@ __base__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'reso
 __libraries__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'libraries')).decode('utf-8')
 
 sys.path.insert(0, __libraries__)
-sys.path.append(__base__)
+sys.path.insert(0, __base__)
 
 #################################################################################################
 


### PR DESCRIPTION
`resources/lib/entrypoint/service.py` is importing `setup`, which just so happens to be a system package on this computer, which exits on import.

This was leading to a hard to track down (debug prints all the way from entry point) bug with no error message - it just didn't work.

These changes make sure the local addon files are searched first for modules to import, instead of last.