### PR TITLE
Remove dependency on WAN IP Address

### DIFF
--- a/resources/lib/helper/loghandler.py
+++ b/resources/lib/helper/loghandler.py
@@ -53,9 +53,6 @@ class LogHandler(logging.StreamHandler):
             if server.get('LocalAddress'):
                 self.sensitive['Server'].append(server['LocalAddress'].split('://')[1])
 
-            if server.get('RemoteAddress'):
-                self.sensitive['Server'].append(server['RemoteAddress'].split('://')[1])
-
             if server.get('ManualAddress'):
                 self.sensitive['Server'].append(server['ManualAddress'].split('://')[1])
 

--- a/resources/lib/jellyfin/core/connection_manager.py
+++ b/resources/lib/jellyfin/core/connection_manager.py
@@ -599,8 +599,6 @@ class ConnectionManager(object):
 
         if system_info.get('LocalAddress'):
             server['LocalAddress'] = system_info['LocalAddress']
-        if system_info.get('WanAddress'):
-            server['RemoteAddress'] = system_info['WanAddress']
         if 'MacAddress' in system_info:
             server['WakeOnLanInfos'] = [{'MacAddress': system_info['MacAddress']}]
 

--- a/resources/lib/jellyfin/core/connection_manager.py
+++ b/resources/lib/jellyfin/core/connection_manager.py
@@ -25,7 +25,6 @@ CONNECTION_STATE = {
 }
 CONNECTION_MODE = {
     'Local': 0,
-    'Remote': 1,
     'Manual': 2
 }
 
@@ -35,10 +34,9 @@ def get_server_address(server, mode):
 
     modes = {
         CONNECTION_MODE['Local']: server.get('LocalAddress'),
-        CONNECTION_MODE['Remote']: server.get('RemoteAddress'),
         CONNECTION_MODE['Manual']: server.get('ManualAddress')
     }
-    return modes.get(mode) or server.get('ManualAddress', server.get('LocalAddress', server.get('RemoteAddress')))
+    return modes.get(mode) or server.get('ManualAddress', server.get('LocalAddress'))
 
 
 class ConnectionManager(object):
@@ -215,8 +213,6 @@ class ConnectionManager(object):
             tests.append(CONNECTION_MODE['Manual'])
         if CONNECTION_MODE['Local'] not in tests:
             tests.append(CONNECTION_MODE['Local'])
-        if CONNECTION_MODE['Remote'] not in tests:
-            tests.append(CONNECTION_MODE['Remote'])
 
         # TODO: begin to wake server
 

--- a/resources/lib/jellyfin/core/credentials.py
+++ b/resources/lib/jellyfin/core/credentials.py
@@ -99,9 +99,6 @@ class Credentials(object):
                 if server.get('ExchangeToken'):
                     existing['ExchangeToken'] = server['ExchangeToken']
 
-                if server.get('RemoteAddress'):
-                    existing['RemoteAddress'] = server['RemoteAddress']
-
                 if server.get('ManualAddress'):
                     existing['ManualAddress'] = server['ManualAddress']
 


### PR DESCRIPTION
At least partially addresses #26.  Basically just removes all attempts to query the server for the WAN IP address and the "Remote" connection method associated with it.  Doesn't attempt to address the logic around choosing which playback method to attempt