### PR TITLE
Cleanup getitems

### DIFF
--- a/resources/lib/connect.py
+++ b/resources/lib/connect.py
@@ -148,7 +148,7 @@ class Connect(object):
 
         ''' Save user info.
         '''
-        self.user = client['api'].get_user()
+        self.user = client.jellyfin.get_user()
         settings('username', self.user['Name'])
 
         if 'PrimaryImageTag' in self.user:

--- a/resources/lib/connect.py
+++ b/resources/lib/connect.py
@@ -81,9 +81,9 @@ class Connect(object):
         ''' Get Jellyfin client.
         '''
         client = Jellyfin(server_id)
-        client['config/app']("Kodi", self.info['Version'], self.info['DeviceName'], self.info['DeviceId'])
-        client['config']['http.user_agent'] = "Jellyfin-Kodi/%s" % self.info['Version']
-        client['config']['auth.ssl'] = self.get_ssl()
+        client.config.app("Kodi", self.info['Version'], self.info['DeviceName'], self.info['DeviceId'])
+        client.config.data['http.user_agent'] = "Jellyfin-Kodi/%s" % self.info['Version']
+        client.config.data['auth.ssl'] = self.get_ssl()
 
         return client
 
@@ -94,7 +94,7 @@ class Connect(object):
         self.connect_manager = client.auth
 
         if server_id is None:
-            client['config']['app.default'] = True
+            client.config.data['app.default'] = True
 
         try:
             state = client.authenticate(credentials or {}, options or {})
@@ -107,8 +107,8 @@ class Connect(object):
                     client.callback = event
                     self.get_user(client)
 
-                    settings('serverName', client['config/auth.server-name'])
-                    settings('server', client['config/auth.server'])
+                    settings('serverName', client.config.data['auth.server-name'])
+                    settings('server', client.config.data['auth.server'])
 
                 event('ServerOnline', {'ServerId': server_id})
                 event('LoadServer', {'ServerId': server_id})
@@ -152,7 +152,9 @@ class Connect(object):
         settings('username', self.user['Name'])
 
         if 'PrimaryImageTag' in self.user:
-            window('JellyfinUserImage', api.API(self.user, client['auth/server-address']).get_user_artwork(self.user['Id']))
+            server_data = client.auth.get_server_info(client.auth.server_id)
+            server_address = client.auth.get_server_address(server_data, server_data['LastConnectionMode'])
+            window('JellyfinUserImage', api.API(self.user, server_address).get_user_artwork(self.user['Id']))
 
     def select_servers(self, state=None):
 
@@ -213,8 +215,9 @@ class Connect(object):
 
     def login(self):
 
-        users = self.connect_manager['public-users']
-        server = self.connect_manager['server-address']
+        users = self.connect_manager.get_public_users()
+        server_data = self.connect_manager.get_server_info(self.connect_manager.server_id)
+        server = self.connect_manager.get_server_address(server_data, server_data['LastConnectionMode'])
 
         if not users:
             try:
@@ -236,7 +239,7 @@ class Connect(object):
                     return self.login_manual(username)
                 except RuntimeError: pass
             else:
-                return self.connect_manager['login'](server, username)
+                return self.connect_manager.login(server, username)
 
         elif dialog.is_manual_login():
             try:

--- a/resources/lib/dialogs/loginmanual.py
+++ b/resources/lib/dialogs/loginmanual.py
@@ -118,9 +118,10 @@ class LoginManual(xbmcgui.WindowXMLDialog):
 
     def _login(self, username, password):
 
-        mode = self.connect_manager['server-mode']
-        server = self.connect_manager['server-address']
-        result = self.connect_manager['login'](server, username, password)
+        mode = self.connect_manager.get_server_info(self.connect_manager.server_id)['LastConnectionMode']
+        server_data = self.connect_manager.get_server_info(self.connect_manager.server_id)
+        server = self.connect_manager.get_server_address(server_data, server_data['LastConnectionMode'])
+        result = self.connect_manager.login(server, username, password)
 
         if not result:
             self._error(ERROR['Invalid'], _('invalid_auth'))

--- a/resources/lib/dialogs/serverconnect.py
+++ b/resources/lib/dialogs/serverconnect.py
@@ -116,7 +116,7 @@ class ServerConnect(xbmcgui.WindowXMLDialog):
         self.message_box.setVisibleCondition('true')
         self.busy.setVisibleCondition('true')
 
-        result = self.connect_manager['connect-to-server'](server)
+        result = self.connect_manager.connect_to_server(server)
 
         if result['State'] == CONNECTION_STATE['Unavailable']:
             self.busy.setVisibleCondition('false')

--- a/resources/lib/dialogs/servermanual.py
+++ b/resources/lib/dialogs/servermanual.py
@@ -118,7 +118,7 @@ class ServerManual(xbmcgui.WindowXMLDialog):
 
         server_address = "%s:%s" % (server, port) if port else server
         self._message("%s %s..." % (_(30610), server_address))
-        result = self.connect_manager['manual-server'](server_address)
+        result = self.connect_manager.connect_to_address(server_address)
 
         if result['State'] == CONNECTION_STATE['Unavailable']:
             self._message(_(30609))

--- a/resources/lib/downloader.py
+++ b/resources/lib/downloader.py
@@ -40,9 +40,7 @@ def browse_info():
 
 def _http(action, url, request={}, server_id=None):
     request.update({'url': url, 'type': action})
-
-    return Jellyfin(server_id)['http/request'](request)
-
+    return Jellyfin(server_id).http.request(request)
 
 def _get(handler, params=None, server_id=None):
     return _http("GET", get_jellyfinserver_url(handler), {'params': params}, server_id)
@@ -305,7 +303,7 @@ class GetItemWorker(threading.Thread):
                 }
 
                 try:
-                    result = self.server['http/request'](request, s)
+                    result = self.server.http.request(request, s)
 
                     for item in result['Items']:
 

--- a/resources/lib/full_sync.py
+++ b/resources/lib/full_sync.py
@@ -228,7 +228,7 @@ class FullSync(object):
 
                 return
 
-            library = self.server['api'].get_item(library_id.replace('Mixed:', ""))
+            library = self.server.jellyfin.get_item(library_id.replace('Mixed:', ""))
 
             if library_id.startswith('Mixed:'):
                 for mixed in ('movies', 'tvshows'):

--- a/resources/lib/helper/wrapper.py
+++ b/resources/lib/helper/wrapper.py
@@ -136,7 +136,7 @@ def library_check():
                         view = None
 
                 if view is None:
-                    ancestors = self.server['api'].get_ancestors(item['Id'])
+                    ancestors = self.server.jellyfin.get_ancestors(item['Id'])
 
                     if not ancestors:
                         if item['Type'] == 'MusicArtist':

--- a/resources/lib/jellyfin/__init__.py
+++ b/resources/lib/jellyfin/__init__.py
@@ -45,11 +45,11 @@ class Jellyfin(object):
 
         from jellyfin import Jellyfin
 
-        Jellyfin('123456')['config/app']
+        Jellyfin('123456').config.data['app']
 
         # Permanent client reference
         client = Jellyfin('123456').get_client()
-        client['config/app']
+        client.config.data['app']
     '''
 
     # Borg - multiple instances, shared state

--- a/resources/lib/jellyfin/__init__.py
+++ b/resources/lib/jellyfin/__init__.py
@@ -110,11 +110,6 @@ class Jellyfin(object):
     def __getattr__(self, name):
         return getattr(self.client[self.server_id], name)
 
-    @ensure_client()
-    def __getitem__(self, key):
-        LOG.debug("__getitem__(%r)", key)
-        return self.client[self.server_id][key]
-
     def construct(self):
 
         self.client[self.server_id] = JellyfinClient()

--- a/resources/lib/jellyfin/client.py
+++ b/resources/lib/jellyfin/client.py
@@ -55,7 +55,7 @@ class JellyfinClient(object):
 
             LOG.info("User is authenticated.")
             self.logged_in = True
-            self.callback("ServerOnline", {'Id': self['auth/server-id']})
+            self.callback("ServerOnline", {'Id': self.auth.server_id})
 
         state['Credentials'] = self.get_credentials()
 
@@ -81,23 +81,3 @@ class JellyfinClient(object):
 
         self.wsc.stop_client()
         self.http.stop_session()
-
-    def __getitem__(self, key):
-        LOG.debug("__getitem__(%r)", key)
-
-        if key.startswith('config'):
-            return self.config[key.replace('config/', "", 1)] if "/" in key else self.config
-
-        elif key.startswith('websocket'):
-            return self.wsc.__shortcuts__(key.replace('websocket/', "", 1))
-
-        elif key.startswith('callback'):
-            return self.callback_ws if 'ws' in key else self.callback
-
-        elif key.startswith('auth'):
-            return self.auth.__shortcuts__(key.replace('auth/', "", 1))
-
-        elif key == 'connected':
-            return self.logged_in
-
-        return

--- a/resources/lib/jellyfin/client.py
+++ b/resources/lib/jellyfin/client.py
@@ -88,9 +88,6 @@ class JellyfinClient(object):
         if key.startswith('config'):
             return self.config[key.replace('config/', "", 1)] if "/" in key else self.config
 
-        elif key.startswith('http'):
-            return self.http.__shortcuts__(key.replace('http/', "", 1))
-
         elif key.startswith('websocket'):
             return self.wsc.__shortcuts__(key.replace('websocket/', "", 1))
 
@@ -99,9 +96,6 @@ class JellyfinClient(object):
 
         elif key.startswith('auth'):
             return self.auth.__shortcuts__(key.replace('auth/', "", 1))
-
-        elif key.startswith('api'):
-            return self.jellyfin
 
         elif key == 'connected':
             return self.logged_in

--- a/resources/lib/jellyfin/core/api.py
+++ b/resources/lib/jellyfin/core/api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 def jellyfin_url(client, handler):
-    return "%s/emby/%s" % (client.config['auth.server'], handler)
+    return "%s/emby/%s" % (client.config.data['auth.server'], handler)
 
 
 def basic_info():

--- a/resources/lib/jellyfin/core/configuration.py
+++ b/resources/lib/jellyfin/core/configuration.py
@@ -25,27 +25,6 @@ class Config(object):
         self.data = {}
         self.http()
 
-    def __shortcuts__(self, key):
-        LOG.debug("__shortcuts__(%r)", key)
-
-        if key == "auth":
-            return self.auth
-        elif key == "app":
-            return self.app
-        elif key == "http":
-            return self.http
-        elif key == "data":
-            return self
-
-        return
-
-    def __getitem__(self, key):
-        LOG.debug("__getitem__(%r)", key)
-        return self.data.get(key, self.__shortcuts__(key))
-
-    def __setitem__(self, key, value):
-        self.data[key] = value
-
     def app(self, name, version, device_name, device_id, capabilities=None, device_pixel_ratio=None):
         LOG.info("Begin app constructor.")
 

--- a/resources/lib/jellyfin/core/connection_manager.py
+++ b/resources/lib/jellyfin/core/connection_manager.py
@@ -57,48 +57,6 @@ class ConnectionManager(object):
 
         self.http = HTTP(client)
 
-    def __shortcuts__(self, key):
-        LOG.debug("__shortcuts__(%r)", key)
-
-        if key == "clear":
-            return self.clear_data
-        elif key == "servers":
-            return self.get_available_servers()
-        elif key in ("reconnect", "refresh"):
-            return self.connect
-        elif key == "login":
-            return self.login
-        elif key == "server":
-            return self.get_server_info(self.server_id)
-        elif key == "server-id":
-            return self.server_id
-        elif key == "server-version":
-            return self.server_version
-        elif key == "user-id":
-            return self.jellyfin_user_id()
-        elif key == "public-users":
-            return self.get_public_users()
-        elif key == "token":
-            return self.jellyfin_token()
-        elif key == "manual-server":
-            return self.connect_to_address
-        elif key == "connect-to-server":
-            return self.connect_to_server
-        elif key == "server-address":
-            server = self.get_server_info(self.server_id)
-            return get_server_address(server, server['LastConnectionMode'])
-        elif key == "revoke-token":
-            return self.revoke_token()
-        elif key == "server-mode":
-            server = self.get_server_info(self.server_id)
-            return server['LastConnectionMode']
-
-        return
-
-    def __getitem__(self, key):
-        LOG.debug("__getitem__(%r)", key)
-        return self.__shortcuts__(key)
-
     def clear_data(self):
 
         LOG.info("connection manager clearing data")
@@ -117,7 +75,7 @@ class ConnectionManager(object):
         self['server']['AccessToken'] = None
         self.credentials.get_credentials(self.credentials.get_credentials())
 
-        self.config['auth.token'] = None
+        self.config.data['auth.token'] = None
 
     def get_available_servers(self):
 
@@ -151,7 +109,7 @@ class ConnectionManager(object):
 
         if not server:
             raise AttributeError("server cannot be empty")
-
+            
         try:
             request = {
                 'type': "POST",
@@ -219,6 +177,14 @@ class ConnectionManager(object):
         LOG.info("beginning connection tests")
         return self._test_next_connection_mode(tests, 0, server, options)
 
+    def get_server_address(self, server, mode): #TODO: De-duplicated (Duplicated from above when getting rid of shortcuts)
+
+        modes = {
+            CONNECTION_MODE['Local']: server.get('LocalAddress'),
+            CONNECTION_MODE['Manual']: server.get('ManualAddress')
+        }
+        return modes.get(mode) or server.get('ManualAddress', server.get('LocalAddress'))
+
     def connect(self, options={}):
 
         LOG.info("Begin connect")
@@ -261,7 +227,7 @@ class ConnectionManager(object):
             raise
 
     def _add_app_info(self):
-        return "%s/%s" % (self.config['app.name'], self.config['app.version'])
+        return "%s/%s" % (self.config.data['app.name'], self.config.data['app.version'])
 
     def _get_headers(self, request):
 
@@ -526,15 +492,15 @@ class ConnectionManager(object):
 
         if options.get('enableAutoLogin') == False:
 
-            self.config['auth.user_id'] = server.pop('UserId', None)
-            self.config['auth.token'] = server.pop('AccessToken', None)
+            self.config.data['auth.user_id'] = server.pop('UserId', None)
+            self.config.data['auth.token'] = server.pop('AccessToken', None)
 
         elif verify_authentication and server.get('AccessToken'):
 
             if self._validate_authentication(server, connection_mode, options) is not False:
 
-                self.config['auth.user_id'] = server['UserId']
-                self.config['auth.token'] = server['AccessToken']
+                self.config.data['auth.user_id'] = server['UserId']
+                self.config.data['auth.token'] = server['AccessToken']
                 return self._after_connect_validated(server, credentials, system_info, connection_mode, False, options)
 
             return self._resolve_failure()
@@ -551,10 +517,10 @@ class ConnectionManager(object):
         self.server_id = server['Id']
 
         # Update configs
-        self.config['auth.server'] = get_server_address(server, connection_mode)
-        self.config['auth.server-name'] = server['Name']
-        self.config['auth.server=id'] = server['Id']
-        self.config['auth.ssl'] = options.get('ssl', self.config['auth.ssl'])
+        self.config.data['auth.server'] = get_server_address(server, connection_mode)
+        self.config.data['auth.server-name'] = server['Name']
+        self.config.data['auth.server=id'] = server['Id']
+        self.config.data['auth.ssl'] = options.get('ssl', self.config.data['auth.ssl'])
 
         result = {
             'Servers': [server]
@@ -602,8 +568,8 @@ class ConnectionManager(object):
 
         credentials = self.credentials.get_credentials()
 
-        self.config['auth.user_id'] = result['User']['Id']
-        self.config['auth.token'] = result['AccessToken']
+        self.config.data['auth.user_id'] = result['User']['Id']
+        self.config.data['auth.token'] = result['AccessToken']
 
         for server in credentials['Servers']:
             if server['Id'] == result['ServerId']:

--- a/resources/lib/jellyfin/core/http.py
+++ b/resources/lib/jellyfin/core/http.py
@@ -122,11 +122,19 @@ class HTTP(object):
                 if r.status_code == 401:
 
                     if 'X-Application-Error-Code' in r.headers:
+<<<<<<< HEAD
                         self.client.callback("AccessRestricted", {'ServerId': self.config.data['auth.server-id']})
 
                         raise HTTPException("AccessRestricted", error)
                     else:
                         self.client.callback("Unauthorized", {'ServerId': self.config.data['auth.server-id']})
+=======
+                        self.client['callback']("AccessRestricted", {'ServerId': self.config.data['auth.server-id']})
+
+                        raise HTTPException("AccessRestricted", error)
+                    else:
+                        self.client['callback']("Unauthorized", {'ServerId': self.config.data['auth.server-id']})
+>>>>>>> 8268ec3f44657ec4dc448a8a02bbb51841972be9
                         self.client.auth.revoke_token() 
 
                         raise HTTPException("Unauthorized", error)

--- a/resources/lib/jellyfin/core/http.py
+++ b/resources/lib/jellyfin/core/http.py
@@ -26,14 +26,6 @@ class HTTP(object):
         self.client = client
         self.config = client['config']
 
-    def __shortcuts__(self, key):
-        LOG.debug("__shortcuts__(%r)", key)
-
-        if key == "request":
-            return self.request
-
-        return
-
     def start_session(self):
 
         self.session = requests.Session()

--- a/resources/lib/jellyfin/core/http.py
+++ b/resources/lib/jellyfin/core/http.py
@@ -24,13 +24,13 @@ class HTTP(object):
     def __init__(self, client):
 
         self.client = client
-        self.config = client['config']
+        self.config = client.config
 
     def start_session(self):
 
         self.session = requests.Session()
 
-        max_retries = self.config['http.max_retries']
+        max_retries = self.config.data['http.max_retries']
         self.session.mount("http://", requests.adapters.HTTPAdapter(max_retries=max_retries))
         self.session.mount("https://", requests.adapters.HTTPAdapter(max_retries=max_retries))
 
@@ -48,14 +48,14 @@ class HTTP(object):
     def _replace_user_info(self, string):
 
         if '{server}' in string:
-            if self.config['auth.server']:
-                string = string.decode('utf-8').replace("{server}", self.config['auth.server'])
+            if self.config.data['auth.server']:
+                string = string.decode('utf-8').replace("{server}", self.config.data['auth.server'])
             else:
                 raise Exception("Server address not set.")
 
         if '{UserId}'in string:
-            if self.config['auth.user_id']:
-                string = string.decode('utf-8').replace("{UserId}", self.config['auth.user_id'])
+            if self.config.data['auth.user_id']:
+                string = string.decode('utf-8').replace("{UserId}", self.config.data['auth.user_id'])
             else:
                 raise Exception("UserId is not set.")
 
@@ -100,7 +100,7 @@ class HTTP(object):
                     continue
 
                 LOG.error(error)
-                self.client['callback']("ServerUnreachable", {'ServerId': self.config['auth.server-id']})
+                self.client.callback("ServerUnreachable", {'ServerId': self.config.data['auth.server-id']})
 
                 raise HTTPException("ServerUnreachable", error)
 
@@ -122,12 +122,12 @@ class HTTP(object):
                 if r.status_code == 401:
 
                     if 'X-Application-Error-Code' in r.headers:
-                        self.client['callback']("AccessRestricted", {'ServerId': self.config['auth.server-id']})
+                        self.client.callback("AccessRestricted", {'ServerId': self.config.data['auth.server-id']})
 
                         raise HTTPException("AccessRestricted", error)
                     else:
-                        self.client['callback']("Unauthorized", {'ServerId': self.config['auth.server-id']})
-                        self.client['auth/revoke-token']
+                        self.client.callback("Unauthorized", {'ServerId': self.config.data['auth.server-id']})
+                        self.client.auth.revoke_token() 
 
                         raise HTTPException("Unauthorized", error)
 
@@ -147,14 +147,14 @@ class HTTP(object):
                 raise HTTPException(r.status_code, error)
 
             except requests.exceptions.MissingSchema as error:
-                raise HTTPException("MissingSchema", {'Id': self.config['auth.server']})
+                raise HTTPException("MissingSchema", {'Id': self.config.data['auth.server']})
 
             except Exception as error:
                 raise
 
             else:
                 try:
-                    self.config['server-time'] = r.headers['Date']
+                    self.config.data['server-time'] = r.headers['Date']
                     elapsed = int(r.elapsed.total_seconds() * 1000)
                     response = r.json()
                     LOG.debug("---<[ http ][%s ms]", elapsed)
@@ -167,11 +167,11 @@ class HTTP(object):
     def _request(self, data):
 
         if 'url' not in data:
-            data['url'] = "%s/emby/%s" % (self.config['auth.server'], data.pop('handler', ""))
+            data['url'] = "%s/emby/%s" % (self.config.data['auth.server'], data.pop('handler', ""))
 
         self._get_header(data)
-        data['timeout'] = data.get('timeout') or self.config['http.timeout']
-        data['verify'] = data.get('verify') or self.config['auth.ssl'] or False
+        data['timeout'] = data.get('timeout') or self.config.data['http.timeout']
+        data['verify'] = data.get('verify') or self.config.data['auth.ssl'] or False
         data['url'] = self._replace_user_info(data['url'])
         self._process_params(data.get('params') or {})
         self._process_params(data.get('json') or {})
@@ -198,7 +198,7 @@ class HTTP(object):
                 'Content-type': "application/json",
                 'Accept-Charset': "UTF-8,*",
                 'Accept-encoding': "gzip",
-                'User-Agent': self.config['http.user_agent'] or "%s/%s" % (self.config['app.name'], self.config['app.version'])
+                'User-Agent': self.config.data['http.user_agent'] or "%s/%s" % (self.config.data['app.name'], self.config.data['app.version'])
             })
 
         if 'x-emby-authorization' not in data['headers']:
@@ -209,17 +209,17 @@ class HTTP(object):
     def _authorization(self, data):
 
         auth = "MediaBrowser "
-        auth += "Client=%s, " % self.config['app.name'].encode('utf-8')
-        auth += "Device=%s, " % self.config['app.device_name'].encode('utf-8')
-        auth += "DeviceId=%s, " % self.config['app.device_id'].encode('utf-8')
-        auth += "Version=%s" % self.config['app.version'].encode('utf-8')
+        auth += "Client=%s, " % self.config.data['app.name'].encode('utf-8')
+        auth += "Device=%s, " % self.config.data['app.device_name'].encode('utf-8')
+        auth += "DeviceId=%s, " % self.config.data['app.device_id'].encode('utf-8')
+        auth += "Version=%s" % self.config.data['app.version'].encode('utf-8')
 
         data['headers'].update({'x-emby-authorization': auth})
 
-        if self.config['auth.token'] and self.config['auth.user_id']:
+        if self.config.data.get('auth.token') and self.config.data.get('auth.user_id'):
 
-            auth += ', UserId=%s' % self.config['auth.user_id'].encode('utf-8')
-            data['headers'].update({'x-emby-authorization': auth, 'X-MediaBrowser-Token': self.config['auth.token'].encode('utf-8')})
+            auth += ', UserId=%s' % self.config.data['auth.user_id'].encode('utf-8')
+            data['headers'].update({'x-emby-authorization': auth, 'X-MediaBrowser-Token': self.config.data['auth.token'].encode('utf-8')})
 
         return data
 

--- a/resources/lib/jellyfin/core/ws_client.py
+++ b/resources/lib/jellyfin/core/ws_client.py
@@ -30,16 +30,6 @@ class WSClient(threading.Thread):
         self.client = client
         threading.Thread.__init__(self)
 
-    def __shortcuts__(self, key):
-        LOG.debug("__shortcuts__(%r)", key)
-
-        if key == "send":
-            return self.send
-        elif key == "stop":
-            return self.stop_client()
-
-        return
-
     def send(self, message, data=""):
 
         if self.wsc is None:
@@ -50,9 +40,9 @@ class WSClient(threading.Thread):
     def run(self):
 
         monitor = xbmc.Monitor()
-        token = self.client['config/auth.token']
-        device_id = self.client['config/app.device_id']
-        server = self.client['config/auth.server']
+        token = self.client.config.data['auth.token']
+        device_id = self.client.config.data['app.device_id']
+        server = self.client.config.data['auth.server']
         server = server.replace('https', "wss") if server.startswith('https') else server.replace('http', "ws")
         wsc_url = "%s/embywebsocket?api_key=%s&device_id=%s" % (server, token, device_id)
 
@@ -88,10 +78,10 @@ class WSClient(threading.Thread):
 
             return
 
-        if not self.client['config/app.default']:
-            data['ServerId'] = self.client['auth/server-id']
+        if not self.client.config.data['app.default']:
+            data['ServerId'] = self.client.auth.server_id
 
-        self.client['callback_ws'](message['MessageType'], data)
+        self.client.callback(message['MessageType'], data)
 
     def stop_client(self):
 

--- a/resources/lib/library.py
+++ b/resources/lib/library.py
@@ -348,7 +348,7 @@ class Library(threading.Thread):
             if settings('SyncInstallRunDone.bool'):
                 if settings('kodiCompanion.bool'):
 
-                    for plugin in self.server['api'].get_plugins():
+                    for plugin in self.server.jellyfin.get_plugins():
                         if plugin['Name'] in ("Jellyfin.Kodi Sync Queue", "Kodi companion", "Kodi Sync Queue"):
 
                             if not self.fast_sync():
@@ -400,7 +400,7 @@ class Library(threading.Thread):
         """
         for library in sync['Whitelist']:
 
-            data = self.server['api'].get_date_modified(last_sync, library.replace('Mixed:', ""), "Series,Episode,BoxSet,Movie,MusicVideo,MusicArtist,MusicAlbum,Audio")
+            data = self.server.jellyfin.get_date_modified(last_sync, library.replace('Mixed:', ""), "Series,Episode,BoxSet,Movie,MusicVideo,MusicArtist,MusicAlbum,Audio")
             [self.updated_output[query['Type']].put(query) for query in data['Items']]
         """
         try:
@@ -409,7 +409,7 @@ class Library(threading.Thread):
             removed = []
 
             for media in filters:
-                result = self.server['api'].get_sync_queue(last_sync, ",".join([x for x in filters if x != media]))
+                result = self.server.jellyfin.get_sync_queue(last_sync, ",".join([x for x in filters if x != media]))
                 updated.extend(result['ItemsAdded'])
                 updated.extend(result['ItemsUpdated'])
                 userdata.extend(result['UserDataChanged'])
@@ -431,7 +431,7 @@ class Library(threading.Thread):
             self.removed(removed)
 
             """
-            result = self.server['api'].get_sync_queue(last_sync)
+            result = self.server.jellyfin.get_sync_queue(last_sync)
             self.userdata(result['UserDataChanged'])
             self.removed(result['ItemsRemoved'])
 
@@ -439,7 +439,7 @@ class Library(threading.Thread):
             filters.extend(["tvshows", "boxsets", "musicvideos", "music"])
 
             # Get only movies.
-            result = self.server['api'].get_sync_queue(last_sync, ",".join(filters))
+            result = self.server.jellyfin.get_sync_queue(last_sync, ",".join(filters))
             self.updated(result['ItemsAdded'])
             self.updated(result['ItemsUpdated'])
             self.userdata(result['UserDataChanged'])

--- a/resources/lib/library.py
+++ b/resources/lib/library.py
@@ -456,7 +456,7 @@ class Library(threading.Thread):
     def save_last_sync(self):
 
         try:
-            time_now = datetime.strptime(self.server['config/server-time'].split(', ', 1)[1], '%d %b %Y %H:%M:%S GMT') - timedelta(minutes=2)
+            time_now = datetime.strptime(self.server.config.data['server-time'].split(', ', 1)[1], '%d %b %Y %H:%M:%S GMT') - timedelta(minutes=2)
         except Exception as error:
 
             LOG.exception(error)

--- a/resources/lib/monitor.py
+++ b/resources/lib/monitor.py
@@ -125,22 +125,22 @@ class Monitor(xbmc.Monitor):
 
         if method == 'GetItem':
 
-            item = server['api'].get_item(data['Id'])
+            item = server.jellyfin.get_item(data['Id'])
             self.void_responder(data, item)
 
         elif method == 'GetAdditionalParts':
 
-            item = server['api'].get_additional_parts(data['Id'])
+            item = server.jellyfin.get_additional_parts(data['Id'])
             self.void_responder(data, item)
 
         elif method == 'GetIntros':
 
-            item = server['api'].get_intros(data['Id'])
+            item = server.jellyfin.get_intros(data['Id'])
             self.void_responder(data, item)
 
         elif method == 'GetImages':
 
-            item = server['api'].get_images(data['Id'])
+            item = server.jellyfin.get_images(data['Id'])
             self.void_responder(data, item)
 
         elif method == 'GetServerAddress':
@@ -150,12 +150,12 @@ class Monitor(xbmc.Monitor):
 
         elif method == 'GetPlaybackInfo':
 
-            sources = server['api'].get_play_info(data['Id'], data['Profile'])
+            sources = server.jellyfin.get_play_info(data['Id'], data['Profile'])
             self.void_responder(data, sources)
 
         elif method == 'GetLiveStream':
 
-            sources = server['api'].get_live_stream(data['Id'], data['PlaySessionId'], data['Token'], data['Profile'])
+            sources = server.jellyfin.get_live_stream(data['Id'], data['PlaySessionId'], data['Token'], data['Profile'])
             self.void_responder(data, sources)
 
         elif method == 'GetToken':
@@ -165,31 +165,31 @@ class Monitor(xbmc.Monitor):
 
         elif method == 'GetSession':
 
-            session = server['api'].get_device(self.device_id)
+            session = server.jellyfin.get_device(self.device_id)
             self.void_responder(data, session)
 
         elif method == 'GetUsers':
 
-            users = server['api'].get_users()
+            users = server.jellyfin.get_users()
             self.void_responder(data, users)
 
         elif method == 'GetTranscodeOptions':
 
-            result = server['api'].get_transcode_settings()
+            result = server.jellyfin.get_transcode_settings()
             self.void_responder(data, result)
 
         elif method == 'GetThemes':
 
             if data['Type'] == 'Video':
-                theme = server['api'].get_items_theme_video(data['Id'])
+                theme = server.jellyfin.get_items_theme_video(data['Id'])
             else:
-                theme = server['api'].get_items_theme_song(data['Id'])
+                theme = server.jellyfin.get_items_theme_song(data['Id'])
 
             self.void_responder(data, theme)
 
         elif method == 'GetTheme':
 
-            theme = server['api'].get_themes(data['Id'])
+            theme = server.jellyfin.get_themes(data['Id'])
             self.void_responder(data, theme)
 
         elif method == 'Browse':
@@ -201,41 +201,41 @@ class Monitor(xbmc.Monitor):
 
         elif method == 'BrowseSeason':
 
-            result = server['api'].get_seasons(data['Id'])
+            result = server.jellyfin.get_seasons(data['Id'])
             self.void_responder(data, result)
 
         elif method == 'LiveTV':
 
-            result = server['api'].get_channels()
+            result = server.jellyfin.get_channels()
             self.void_responder(data, result)
 
         elif method == 'RecentlyAdded':
 
-            result = server['api'].get_recently_added(data.get('Media'), data.get('Id'), data.get('Limit'))
+            result = server.jellyfin.get_recently_added(data.get('Media'), data.get('Id'), data.get('Limit'))
             self.void_responder(data, result)
 
         elif method == 'Genres':
 
-            result = server['api'].get_genres(data.get('Id'))
+            result = server.jellyfin.get_genres(data.get('Id'))
             self.void_responder(data, result)
 
         elif method == 'Recommended':
 
-            result = server['api'].get_recommendation(data.get('Id'), data.get('Limit'))
+            result = server.jellyfin.get_recommendation(data.get('Id'), data.get('Limit'))
             self.void_responder(data, result)
 
         elif method == 'RefreshItem':
-            server['api'].refresh_item(data['Id'])
+            server.jellyfin.refresh_item(data['Id'])
 
         elif method == 'FavoriteItem':
-            server['api'].favorite(data['Id'], data['Favorite'])
+            server.jellyfin.favorite(data['Id'], data['Favorite'])
 
         elif method == 'DeleteItem':
-            server['api'].delete_item(data['Id'])
+            server.jellyfin.delete_item(data['Id'])
 
         elif method == 'PlayPlaylist':
 
-            server['api'].post_session(server['config/app.session'], "Playing", {
+            server.jellyfin.post_session(server['config/app.session'], "Playing", {
                 'PlayCommand': "PlayNow",
                 'ItemIds': data['Id'],
                 'StartPositionTicks': 0
@@ -243,7 +243,7 @@ class Monitor(xbmc.Monitor):
 
         elif method == 'Play':
 
-            items = server['api'].get_items(data['ItemIds'])
+            items = server.jellyfin.get_items(data['ItemIds'])
 
             PlaylistWorker(data.get('ServerId'), items, data['PlayCommand'] == 'PlayNow',
                            data.get('StartPositionTicks', 0), data.get('AudioStreamIndex'),
@@ -262,7 +262,7 @@ class Monitor(xbmc.Monitor):
             self.server_instance(data['ServerId'])
 
         elif method == 'AddUser':
-            server['api'].session_add_user(server['config/app.session'], data['Id'], data['Add'])
+            server.jellyfin.session_add_user(server['config/app.session'], data['Id'], data['Add'])
             self.additional_users(server)
 
         elif method == 'Player.OnPlay':
@@ -286,20 +286,20 @@ class Monitor(xbmc.Monitor):
         elif settings('additionalUsers'):
 
             users = settings('additionalUsers').split(',')
-            all_users = server['api'].get_users()
+            all_users = server.jellyfin.get_users()
 
             for additional in users:
                 for user in all_users:
 
                     if user['Name'].lower() in additional.decode('utf-8').lower():
-                        server['api'].session_add_user(server['config/app.session'], user['Id'], True)
+                        server.jellyfin.session_add_user(server['config/app.session'], user['Id'], True)
 
             self.additional_users(server)
 
     def post_capabilities(self, server):
         LOG.info("--[ post capabilities/%s ]", server['auth/server-id'])
 
-        server['api'].post_capabilities({
+        server.jellyfin.post_capabilities({
             'PlayableMediaTypes': "Audio,Video",
             'SupportsMediaControl': True,
             'SupportedCommands': (
@@ -315,7 +315,7 @@ class Monitor(xbmc.Monitor):
             ),
         })
 
-        session = server['api'].get_device(self.device_id)
+        session = server.jellyfin.get_device(self.device_id)
         server['config']['app.session'] = session[0]['Id']
 
     def additional_users(self, server):
@@ -326,7 +326,7 @@ class Monitor(xbmc.Monitor):
             window('JellyfinAdditionalUserImage.%s' % i, clear=True)
 
         try:
-            session = server['api'].get_device(self.device_id)
+            session = server.jellyfin.get_device(self.device_id)
         except Exception as error:
             LOG.exception(error)
 
@@ -334,7 +334,7 @@ class Monitor(xbmc.Monitor):
 
         for index, user in enumerate(session[0]['AdditionalUsers']):
 
-            info = server['api'].get_user(user['UserId'])
+            info = server.jellyfin.get_user(user['UserId'])
             image = api.API(info, server['config/auth.server']).get_user_artwork(user['UserId'])
             window('JellyfinAdditionalUserImage.%s' % index, image)
             window('JellyfinAdditionalUserPosition.%s' % user['UserId'], str(index))

--- a/resources/lib/objects/actions.py
+++ b/resources/lib/objects/actions.py
@@ -729,7 +729,7 @@ def on_update(data, server):
     if item:
 
         if not window('jellyfin.skip.%s.bool' % item[0]):
-            server['api'].item_played(item[0], playcount)
+            server.jellyfin.item_played(item[0], playcount)
 
         window('jellyfin.skip.%s' % item[0], clear=True)
 
@@ -777,7 +777,7 @@ def on_play(data, server):
 
                 return
 
-            item = server['api'].get_item(item[0])
+            item = server.jellyfin.get_item(item[0])
             item['PlaybackInfo'] = {'Path': file}
             playutils.set_properties(item, 'DirectStream' if settings('useDirectPaths') == '0' else 'DirectPlay')
 

--- a/resources/lib/objects/movies.py
+++ b/resources/lib/objects/movies.py
@@ -34,18 +34,6 @@ class Movies(KodiDb):
 
         KodiDb.__init__(self, videodb.cursor)
 
-    def __getitem__(self, key):
-        LOG.debug("__getitem__(%r)", key)
-
-        if key == 'Movie':
-            return self.movie
-        elif key == 'BoxSet':
-            return self.boxset
-        elif key == 'UserData':
-            return self.userdata
-        elif key in 'Removed':
-            return self.remove
-
     @stop()
     @jellyfin_item()
     @library_check()

--- a/resources/lib/objects/movies.py
+++ b/resources/lib/objects/movies.py
@@ -169,7 +169,7 @@ class Movies(KodiDb):
         try:
             if obj['LocalTrailer']:
 
-                trailer = self.server['api'].get_local_trailers(obj['Id'])
+                trailer = self.server.jellyfin.get_local_trailers(obj['Id'])
                 obj['Trailer'] = "plugin://plugin.video.jellyfin/trailer?id=%s&mode=play" % trailer[0]['Id']
 
             elif obj['Trailer']:

--- a/resources/lib/objects/movies.py
+++ b/resources/lib/objects/movies.py
@@ -54,7 +54,9 @@ class Movies(KodiDb):
         ''' If item does not exist, entry will be added.
             If item exists, entry will be updated.
         '''
-        API = api.API(item, self.server['auth/server-address'])
+        server_data = self.server.auth.get_server_info(self.server.auth.server_id)
+        server_address = self.server.auth.get_server_address(server_data, server_data['LastConnectionMode'])
+        API = api.API(item, server_address)
         obj = self.objects.map(item, 'Movie')
         update = True
 
@@ -213,7 +215,9 @@ class Movies(KodiDb):
             Process movies inside boxset.
             Process removals from boxset.
         '''
-        API = api.API(item, self.server['auth/server-address'])
+        server_data = self.server.auth.get_server_info(self.server.auth.server_id)
+        server_address = self.server.auth.get_server_address(server_data, server_data['LastConnectionMode'])
+        API = api.API(item, server_address)
         obj = self.objects.map(item, 'Boxset')
 
         obj['Overview'] = API.get_overview(obj['Overview'])
@@ -291,7 +295,9 @@ class Movies(KodiDb):
         ''' This updates: Favorite, LastPlayedDate, Playcount, PlaybackPositionTicks
             Poster with progress bar
         '''
-        API = api.API(item, self.server['auth/server-address'])
+        server_data = self.server.auth.get_server_info(self.server.auth.server_id)
+        server_address = self.server.auth.get_server_address(server_data, server_data['LastConnectionMode'])
+        API = api.API(item, server_address)
         obj = self.objects.map(item, 'MovieUserData')
 
         try:

--- a/resources/lib/objects/music.py
+++ b/resources/lib/objects/music.py
@@ -217,7 +217,7 @@ class Music(KodiDb):
             except TypeError:
 
                 try:
-                    self.artist(self.server['api'].get_item(temp_obj['Id']), library=None)
+                    self.artist(self.server.jellyfin.get_item(temp_obj['Id']), library=None)
                     temp_obj['ArtistId'] = self.jellyfin_db.get_item_by_id(*values(temp_obj, QUEM.get_item_obj))[0]
                 except Exception as error:
                     LOG.exception(error)
@@ -318,7 +318,7 @@ class Music(KodiDb):
                 if obj['SongAlbumId'] is None:
                     raise TypeError("No album id found associated?")
 
-                self.album(self.server['api'].get_item(obj['SongAlbumId']))
+                self.album(self.server.jellyfin.get_item(obj['SongAlbumId']))
                 obj['AlbumId'] = self.jellyfin_db.get_item_by_id(*values(obj, QUEM.get_item_song_obj))[0]
             except TypeError:
                 self.single(obj)
@@ -373,7 +373,7 @@ class Music(KodiDb):
             except TypeError:
 
                 try:
-                    self.artist(self.server['api'].get_item(temp_obj['Id']), library=None)
+                    self.artist(self.server.jellyfin.get_item(temp_obj['Id']), library=None)
                     temp_obj['ArtistId'] = self.jellyfin_db.get_item_by_id(*values(temp_obj, QUEM.get_item_obj))[0]
                 except Exception as error:
                     LOG.exception(error)
@@ -407,7 +407,7 @@ class Music(KodiDb):
             except TypeError:
 
                 try:
-                    self.artist(self.server['api'].get_item(temp_obj['Id']), library=None)
+                    self.artist(self.server.jellyfin.get_item(temp_obj['Id']), library=None)
                     temp_obj['ArtistId'] = self.jellyfin_db.get_item_by_id(*values(temp_obj, QUEM.get_item_obj))[0]
                 except Exception as error:
                     LOG.exception(error)

--- a/resources/lib/objects/music.py
+++ b/resources/lib/objects/music.py
@@ -34,20 +34,6 @@ class Music(KodiDb):
 
         KodiDb.__init__(self, musicdb.cursor)
 
-    def __getitem__(self, key):
-        LOG.debug("__getitem__(%r)", key)
-
-        if key in ('MusicArtist', 'AlbumArtist'):
-            return self.artist
-        elif key == 'MusicAlbum':
-            return self.album
-        elif key == 'Audio':
-            return self.song
-        elif key == 'UserData':
-            return self.userdata
-        elif key in 'Removed':
-            return self.remove
-
     @stop()
     @jellyfin_item()
     @library_check()

--- a/resources/lib/objects/music.py
+++ b/resources/lib/objects/music.py
@@ -56,7 +56,9 @@ class Music(KodiDb):
         ''' If item does not exist, entry will be added.
             If item exists, entry will be updated.
         '''
-        API = api.API(item, self.server['auth/server-address'])
+        server_data = self.server.auth.get_server_info(self.server.auth.server_id)
+        server_address = self.server.auth.get_server_address(server_data, server_data['LastConnectionMode'])
+        API = api.API(item, server_address)
         obj = self.objects.map(item, 'Artist')
         update = True
 
@@ -125,7 +127,9 @@ class Music(KodiDb):
 
         ''' Update object to kodi.
         '''
-        API = api.API(item, self.server['auth/server-address'])
+        server_data = self.server.auth.get_server_info(self.server.auth.server_id)
+        server_address = self.server.auth.get_server_address(server_data, server_data['LastConnectionMode'])
+        API = api.API(item, server_address)
         obj = self.objects.map(item, 'Album')
         update = True
 
@@ -234,7 +238,9 @@ class Music(KodiDb):
 
         ''' Update object to kodi.
         '''
-        API = api.API(item, self.server['auth/server-address'])
+        server_data = self.server.auth.get_server_info(self.server.auth.server_id)
+        server_address = self.server.auth.get_server_address(server_data, server_data['LastConnectionMode'])
+        API = api.API(item, server_address)
         obj = self.objects.map(item, 'Song')
         update = True
 
@@ -352,7 +358,9 @@ class Music(KodiDb):
             obj['Path'] = obj['Path'].replace(obj['Filename'], "")
 
         else:
-            obj['Path'] = "%s/emby/Audio/%s/" % (self.server['auth/server-address'], obj['Id'])
+            server_data = self.server.auth.get_server_info(self.server.auth.server_id)
+            server_address = self.server.auth.get_server_address(server_data, server_data['LastConnectionMode'])
+            obj['Path'] = "%s/emby/Audio/%s/" % (server_address, obj['Id'])
             obj['Filename'] = "stream.%s?static=true" % obj['Container']
 
     def song_artist_discography(self, obj):
@@ -429,7 +437,9 @@ class Music(KodiDb):
         ''' This updates: Favorite, LastPlayedDate, Playcount, PlaybackPositionTicks
             Poster with progress bar
         '''
-        API = api.API(item, self.server['auth/server-address'])
+        server_data = self.server.auth.get_server_info(self.server.auth.server_id)
+        server_address = self.server.auth.get_server_address(server_data, server_data['LastConnectionMode'])
+        API = api.API(item, server_address)
         obj = self.objects.map(item, 'SongUserData')
 
         try:

--- a/resources/lib/objects/musicvideos.py
+++ b/resources/lib/objects/musicvideos.py
@@ -34,16 +34,6 @@ class MusicVideos(KodiDb):
 
         KodiDb.__init__(self, videodb.cursor)
 
-    def __getitem__(self, key):
-        LOG.debug("__getitem__(%r)", key)
-
-        if key == 'MusicVideo':
-            return self.musicvideo
-        elif key == 'UserData':
-            return self.userdata
-        elif key in 'Removed':
-            return self.remove
-
     @stop()
     @jellyfin_item()
     @library_check()

--- a/resources/lib/objects/musicvideos.py
+++ b/resources/lib/objects/musicvideos.py
@@ -55,7 +55,9 @@ class MusicVideos(KodiDb):
             If we don't get the track number from Jellyfin, see if we can infer it
             from the sortname attribute.
         '''
-        API = api.API(item, self.server['auth/server-address'])
+        server_data = self.server.auth.get_server_info(self.server.auth.server_id)
+        server_address = self.server.auth.get_server_address(server_data, server_data['LastConnectionMode'])
+        API = api.API(item, server_address)
         obj = self.objects.map(item, 'MusicVideo')
         update = True
 
@@ -192,7 +194,9 @@ class MusicVideos(KodiDb):
         ''' This updates: Favorite, LastPlayedDate, Playcount, PlaybackPositionTicks
             Poster with progress bar
         '''
-        API = api.API(item, self.server['auth/server-address'])
+        server_data = self.server.auth.get_server_info(self.server.auth.server_id)
+        server_address = self.server.auth.get_server_address(server_data, server_data['LastConnectionMode'])        
+        API = api.API(item, server_address)
         obj = self.objects.map(item, 'MusicVideoUserData')
 
         try:

--- a/resources/lib/objects/tvshows.py
+++ b/resources/lib/objects/tvshows.py
@@ -137,7 +137,7 @@ class TVShows(KodiDb):
 
         season_episodes = {}
 
-        for season in self.server['api'].get_seasons(obj['Id'])['Items']:
+        for season in self.server.jellyfin.get_seasons(obj['Id'])['Items']:
 
             if season['SeriesId'] != obj['Id']:
                 obj['SeriesId'] = season['SeriesId']
@@ -435,7 +435,7 @@ class TVShows(KodiDb):
         if obj['ShowId'] is None:
 
             try:
-                self.tvshow(self.server['api'].get_item(obj['SeriesId']), library=None)
+                self.tvshow(self.server.jellyfin.get_item(obj['SeriesId']), library=None)
                 obj['ShowId'] = self.jellyfin_db.get_item_by_id(*values(obj, QUEM.get_item_series_obj))[0]
             except (TypeError, KeyError):
                 LOG.error("Unable to add series %s", obj['SeriesId'])

--- a/resources/lib/objects/tvshows.py
+++ b/resources/lib/objects/tvshows.py
@@ -37,20 +37,6 @@ class TVShows(KodiDb):
 
         KodiDb.__init__(self, videodb.cursor)
 
-    def __getitem__(self, key):
-        LOG.debug("__getitem__(%r)", key)
-
-        if key == 'Series':
-            return self.tvshow
-        elif key == 'Season':
-            return self.season
-        elif key == 'Episode':
-            return self.episode
-        elif key == 'UserData':
-            return self.userdata
-        elif key in 'Removed':
-            return self.remove
-
     @stop()
     @jellyfin_item()
     @library_check()

--- a/resources/lib/objects/tvshows.py
+++ b/resources/lib/objects/tvshows.py
@@ -63,7 +63,9 @@ class TVShows(KodiDb):
             Process seasons.
             Apply series pooling.
         '''
-        API = api.API(item, self.server['auth/server-address'])
+        server_data = self.server.auth.get_server_info(self.server.auth.server_id)
+        server_address = self.server.auth.get_server_address(server_data, server_data['LastConnectionMode'])
+        API = api.API(item, server_address)
         obj = self.objects.map(item, 'Series')
         update = True
 
@@ -230,7 +232,9 @@ class TVShows(KodiDb):
 
             If the show is empty, try to remove it.
         '''
-        API = api.API(item, self.server['auth/server-address'])
+        server_data = self.server.auth.get_server_info(self.server.auth.server_id)
+        server_address = self.server.auth.get_server_address(server_data, server_data['LastConnectionMode'])
+        API = api.API(item, server_address)
         obj = self.objects.map(item, 'Season')
 
         obj['ShowId'] = show_id
@@ -265,7 +269,9 @@ class TVShows(KodiDb):
             Create additional entry for widgets.
             This is only required for plugin/episode.
         '''
-        API = api.API(item, self.server['auth/server-address'])
+        server_data = self.server.auth.get_server_info(self.server.auth.server_id)
+        server_address = self.server.auth.get_server_address(server_data, server_data['LastConnectionMode'])
+        API = api.API(item, server_address)
         obj = self.objects.map(item, 'Episode')
         update = True
 
@@ -459,7 +465,9 @@ class TVShows(KodiDb):
             Make sure there's no other bookmarks created by widget.
             Create additional entry for widgets. This is only required for plugin/episode.
         '''
-        API = api.API(item, self.server['auth/server-address'])
+        server_data = self.server.auth.get_server_info(self.server.auth.server_id)
+        server_address = self.server.auth.get_server_address(server_data, server_data['LastConnectionMode'])
+        API = api.API(item, server_address)
         obj = self.objects.map(item, 'EpisodeUserData')
 
         try:

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -252,8 +252,9 @@ class Player(xbmc.Player):
                     return
 
                 break
-
-        API = api.API(next_item, item['Server']['auth/server-address'])
+        server_data = item['Server'].auth.get_server_info(item['Server'].auth.server_id)
+        server_address = item['Server'].auth.get_server_address(server_data, server_data['LastConnectionMode'])
+        API = api.API(next_item, server_address)
         data = objects.map(next_item, "UpNext")
         artwork = API.get_all_artwork(objects.map(next_item, 'ArtworkParent'), True)
         data['art'] = {

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -110,7 +110,7 @@ class Player(xbmc.Player):
             'AudioStreamIndex': item['AudioStreamIndex'],
             'SubtitleStreamIndex': item['SubtitleStreamIndex']
         }
-        item['Server']['api'].session_playing(data)
+        item['Server'].jellyfin.session_playing(data)
         window('jellyfin.skip.%s.bool' % item['Id'], True)
 
         if monitor.waitForAbort(2):
@@ -239,7 +239,7 @@ class Player(xbmc.Player):
         if item['Type'] != 'Episode' or not item.get('CurrentEpisode'):
             return
 
-        next_items = item['Server']['api'].get_adjacent_episodes(item['CurrentEpisode']['tvshowid'], item['Id'])
+        next_items = item['Server'].jellyfin.get_adjacent_episodes(item['CurrentEpisode']['tvshowid'], item['Id'])
 
         for index, next_item in enumerate(next_items['Items']):
             if next_item['Id'] == item['Id']:
@@ -359,7 +359,7 @@ class Player(xbmc.Player):
             'AudioStreamIndex': item['AudioStreamIndex'],
             'SubtitleStreamIndex': item['SubtitleStreamIndex']
         }
-        item['Server']['api'].session_progress(data)
+        item['Server'].jellyfin.session_progress(data)
 
     def onPlayBackStopped(self):
 
@@ -402,17 +402,17 @@ class Player(xbmc.Player):
                 'PositionTicks': int(item['CurrentPosition'] * 10000000),
                 'PlaySessionId': item['PlaySessionId']
             }
-            item['Server']['api'].session_stop(data)
+            item['Server'].jellyfin.session_stop(data)
 
             if item.get('LiveStreamId'):
 
                 LOG.info("<[ livestream/%s ]", item['LiveStreamId'])
-                item['Server']['api'].close_live_stream(item['LiveStreamId'])
+                item['Server'].jellyfin.close_live_stream(item['LiveStreamId'])
 
             elif item['PlayMethod'] == 'Transcode':
 
                 LOG.info("<[ transcode/%s ]", item['Id'])
-                item['Server']['api'].close_transcode(item['DeviceId'])
+                item['Server'].jellyfin.close_transcode(item['DeviceId'])
 
 
             path = xbmc.translatePath("special://profile/addon_data/plugin.video.jellyfin/temp/").decode('utf-8')
@@ -423,7 +423,7 @@ class Player(xbmc.Player):
                 for file in files:
                     xbmcvfs.delete(os.path.join(path, file.decode('utf-8')))
 
-            result = item['Server']['api'].get_item(item['Id']) or {}
+            result = item['Server'].jellyfin.get_item(item['Id']) or {}
 
             if 'UserData' in result and result['UserData']['Played']:
                 delete = False
@@ -440,7 +440,7 @@ class Player(xbmc.Player):
                     LOG.info("Offer delete option")
 
                     if dialog("yesno", heading=_(30091), line1=_(33015), autoclose=120000):
-                        item['Server']['api'].delete_item(item['Id'])
+                        item['Server'].jellyfin.delete_item(item['Id'])
 
             window('jellyfin.external_check', clear=True)
 

--- a/resources/lib/views.py
+++ b/resources/lib/views.py
@@ -856,15 +856,16 @@ class Views(object):
 
     def window_artwork(self, prop, view_id):
 
-        if not self.server['connected']:
+        if not self.server.logged_in:
             window('%s.artwork' % prop, clear=True)
 
-        elif self.server['connected'] and self.media_folders is not None:
+        elif self.server.logged_in and self.media_folders is not None:
             for library in self.media_folders:
 
                 if library['Id'] == view_id and 'Primary' in library.get('ImageTags', {}):
-
-                    artwork = api.API(None, self.server['auth/server-address']).get_artwork(view_id, 'Primary')
+                    server_data = self.server.auth.get_server_info(self.server.auth.server_id)
+                    server_address = self.server.auth.get_server_address(server_data, server_data['LastConnectionMode'])
+                    artwork = api.API(None, server_address).get_artwork(view_id, 'Primary')
                     window('%s.artwork' % prop, artwork)
 
                     break

--- a/resources/lib/views.py
+++ b/resources/lib/views.py
@@ -167,8 +167,8 @@ class Views(object):
     def get_libraries(self):
 
         try:
-            libraries = self.server['api'].get_media_folders()['Items']
-            views = self.server['api'].get_views()['Items']
+            libraries = self.server.jellyfin.get_media_folders()['Items']
+            views = self.server.jellyfin.get_views()['Items']
         except Exception as error:
             LOG.exception(error)
             raise IndexError("Unable to retrieve libraries: %s" % error)


### PR DESCRIPTION
remove the __getitem__ functions from remaining files as per #27 

__init__.py was bypassed by directly referencing functions which was done in previous commits

for the media files, none of the shortcuts seem to be triggered and no other references to them could be found in the code so they were removed, testing shows no adverse effects 