### PR TITLE
Complete __shortcuts__ and __getitem__ cleanup

### DIFF
--- a/resources/lib/jellyfin/__init__.py
+++ b/resources/lib/jellyfin/__init__.py
@@ -109,12 +109,7 @@ class Jellyfin(object):
     @ensure_client()
     def __getattr__(self, name):
         return getattr(self.client[self.server_id], name)
-
-    @ensure_client()
-    def __getitem__(self, key):
-        LOG.debug("__getitem__(%r)", key)
-        return self.client[self.server_id][key]
-
+        
     def construct(self):
 
         self.client[self.server_id] = JellyfinClient()

--- a/resources/lib/objects/movies.py
+++ b/resources/lib/objects/movies.py
@@ -34,18 +34,6 @@ class Movies(KodiDb):
 
         KodiDb.__init__(self, videodb.cursor)
 
-    def __getitem__(self, key):
-        LOG.debug("__getitem__(%r)", key)
-
-        if key == 'Movie':
-            return self.movie
-        elif key == 'BoxSet':
-            return self.boxset
-        elif key == 'UserData':
-            return self.userdata
-        elif key in 'Removed':
-            return self.remove
-
     @stop()
     @jellyfin_item()
     @library_check()

--- a/resources/lib/objects/music.py
+++ b/resources/lib/objects/music.py
@@ -34,20 +34,6 @@ class Music(KodiDb):
 
         KodiDb.__init__(self, musicdb.cursor)
 
-    def __getitem__(self, key):
-        LOG.debug("__getitem__(%r)", key)
-
-        if key in ('MusicArtist', 'AlbumArtist'):
-            return self.artist
-        elif key == 'MusicAlbum':
-            return self.album
-        elif key == 'Audio':
-            return self.song
-        elif key == 'UserData':
-            return self.userdata
-        elif key in 'Removed':
-            return self.remove
-
     @stop()
     @jellyfin_item()
     @library_check()

--- a/resources/lib/objects/musicvideos.py
+++ b/resources/lib/objects/musicvideos.py
@@ -34,16 +34,6 @@ class MusicVideos(KodiDb):
 
         KodiDb.__init__(self, videodb.cursor)
 
-    def __getitem__(self, key):
-        LOG.debug("__getitem__(%r)", key)
-
-        if key == 'MusicVideo':
-            return self.musicvideo
-        elif key == 'UserData':
-            return self.userdata
-        elif key in 'Removed':
-            return self.remove
-
     @stop()
     @jellyfin_item()
     @library_check()

--- a/resources/lib/objects/tvshows.py
+++ b/resources/lib/objects/tvshows.py
@@ -37,20 +37,6 @@ class TVShows(KodiDb):
 
         KodiDb.__init__(self, videodb.cursor)
 
-    def __getitem__(self, key):
-        LOG.debug("__getitem__(%r)", key)
-
-        if key == 'Series':
-            return self.tvshow
-        elif key == 'Season':
-            return self.season
-        elif key == 'Episode':
-            return self.episode
-        elif key == 'UserData':
-            return self.userdata
-        elif key in 'Removed':
-            return self.remove
-
     @stop()
     @jellyfin_item()
     @library_check()


### PR DESCRIPTION
Completes the code cleanup as detailed in #27 

__init__.py __getitem__ has been bypassed in previous commits and is no longer used

The media files __getitem__ showed no use in searching of the codebase 