### PR TITLE
Remove unnecessary code from server connection

### DIFF
--- a/resources/lib/jellyfin/core/connection_manager.py
+++ b/resources/lib/jellyfin/core/connection_manager.py
@@ -134,8 +134,6 @@ class ConnectionManager(object):
         if not address:
             return False
 
-        address = self._normalize_address(address)
-
         def _on_fail():
             LOG.error("connectToAddress %s failed", address)
             return self._resolve_failure()


### PR DESCRIPTION
The function didn't do much that was useful and was at worst breaking basic auth if the username or password had a capital letter since it was making them all lowercase 