### PR TITLE
Add explicit file encoding to file handlers

### DIFF
--- a/resources/lib/database/__init__.py
+++ b/resources/lib/database/__init__.py
@@ -333,7 +333,7 @@ def get_sync():
         xbmcvfs.mkdirs(path)
 
     try:
-        with open(os.path.join(path, 'sync.json')) as infile:
+        with open(os.path.join(path, 'sync.json'), encoding='utf-8') as infile:
             sync = json.load(infile)
     except Exception:
         sync = {}
@@ -354,7 +354,7 @@ def save_sync(sync):
 
     sync['Date'] = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
 
-    with open(os.path.join(path, 'sync.json'), 'w') as outfile:
+    with open(os.path.join(path, 'sync.json'), 'w', encoding='utf-8') as outfile:
         data = json.dumps(sync, sort_keys=True, indent=4, ensure_ascii=False)
         outfile.write(unicode(data))
 
@@ -371,7 +371,7 @@ def get_credentials():
     except Exception:
 
         try:
-            with open(os.path.join(path, 'data.txt')) as infile:
+            with open(os.path.join(path, 'data.txt'), encoding='utf-8') as infile:
                 credentials = json.load(infile)
                 save_credentials(credentials)
 


### PR DESCRIPTION
As part of one of the log file in #97 there was exceptions noting the system couldn't determine the default encoding thus they're now coded explicitly

>  ERROR: Exception in thread Thread-18:
>                                             Traceback (most recent call last):
>                                               File "/home/jenkins/workspace/Android-ARM64-Leia/tools/depends/xbmc-depends/aarch64-linux-android-21-release/lib/python2.7/threading.py", line 801, in __bootstrap_inner
>                                               File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.jellyfin/resources/lib/library.py", line 101, in run
>                                                 if not self.startup():
>                                               File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.jellyfin/resources/lib/library.py", line 325, in startup
>                                                 Views().get_views()
>                                               File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.jellyfin/resources/lib/views.py", line 221, in get_views
>                                                 save_sync(self.sync)
>                                               File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.jellyfin/resources/lib/database/__init__.py", line 357, in save_sync
>                                                 with open(os.path.join(path, 'sync.json'), 'w') as outfile:
>                                             IOError: could not determine default encoding