### PR TITLE
Remove `libraries/` from PATH

### DIFF
--- a/context.py
+++ b/context.py
@@ -13,9 +13,7 @@ import xbmcaddon
 
 __addon__ = xbmcaddon.Addon(id='plugin.video.jellyfin')
 __base__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'resources', 'lib')).decode('utf-8')
-__libraries__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'libraries')).decode('utf-8')
 
-sys.path.insert(0, __libraries__)
 sys.path.insert(0, __base__)
 
 #################################################################################################

--- a/context_play.py
+++ b/context_play.py
@@ -13,9 +13,7 @@ import xbmcaddon
 
 __addon__ = xbmcaddon.Addon(id='plugin.video.jellyfin')
 __base__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'resources', 'lib')).decode('utf-8')
-__libraries__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'libraries')).decode('utf-8')
 
-sys.path.insert(0, __libraries__)
 sys.path.insert(0, __base__)
 
 #################################################################################################

--- a/default.py
+++ b/default.py
@@ -13,9 +13,7 @@ import xbmcaddon
 
 __addon__ = xbmcaddon.Addon(id='plugin.video.jellyfin')
 __base__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'resources', 'lib')).decode('utf-8')
-__libraries__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'libraries')).decode('utf-8')
 
-sys.path.insert(0, __libraries__)
 sys.path.insert(0, __base__)
 
 #################################################################################################

--- a/service.py
+++ b/service.py
@@ -14,9 +14,7 @@ import xbmcaddon
 
 __addon__ = xbmcaddon.Addon(id='plugin.video.jellyfin')
 __base__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'resources', 'lib')).decode('utf-8')
-__libraries__ = xbmc.translatePath(os.path.join(__addon__.getAddonInfo('path'), 'libraries')).decode('utf-8')
 
-sys.path.insert(0, __libraries__)
 sys.path.insert(0, __base__)
 
 #################################################################################################


### PR DESCRIPTION
Removed "libraries" from PATH inclusion as the folder was deleted back when we pulled in the libraries as dependencies rather than having them in the source in #57 