### PR TITLE
Enclose address input in square brackets if it is an IPv6 address

### DIFF
--- a/resources/lib/dialogs/servermanual.py
+++ b/resources/lib/dialogs/servermanual.py
@@ -4,6 +4,7 @@
 
 import logging
 import os
+import ipaddress
 
 import xbmcgui
 import xbmcaddon
@@ -115,6 +116,12 @@ class ServerManual(xbmcgui.WindowXMLDialog):
         return control
 
     def _connect_to_server(self, server, port):
+        try:
+            addr = ipaddress.ip_address(server.decode('utf-8') if not isinstance(server, type(u'')) else server)
+            if addr.version == 6:
+                server = u"[%s]" % (addr.compressed)
+        except ValueError:
+            pass
 
         server_address = "%s:%s" % (server, port) if port else server
         self._message("%s %s..." % (_(30610), server_address))

--- a/resources/lib/jellyfin/core/connection_manager.py
+++ b/resources/lib/jellyfin/core/connection_manager.py
@@ -453,6 +453,7 @@ class ConnectionManager(object):
         else:
             return servers
 
+    # TODO: Make IPv6 compatable
     def _convert_endpoint_address_to_manual_address(self, info):
 
         if info.get('Address') and info.get('EndpointAddress'):


### PR DESCRIPTION
Fixes #79 

Input `field.getText()` returns a bytestring rather than a unicode string for some reason.