### PR TITLE
Link to new docs location

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The add-on supports a hybrid approach. You can decide which Jellyfin libraries t
 
 ### Install Jellyfin for Kodi
 
-Detailed installation instructions can be found in the [Jellyfin Client Documentation](https://jellyfin.org/docs/general/clients/clients.html#jellyfin-for-kodi).
+Detailed installation instructions can be found in the [Jellyfin Client Documentation](https://docs.jellyfin.org/general/clients/clients.html#jellyfin-for-kodi).
 
 <!-- Get started with the [wiki guide](https://github.com/MediaBrowser/plugin.video.emby/wiki) -->
 


### PR DESCRIPTION
Future proofing.  Move the docs link to the new `docs.jellyfin.org` domain.