### PR TITLE
Remove Empty shows dialog

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -236,10 +236,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr "Benachrichtigung anzeigen ab wieviel anstehenden Updates"
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr "Serien ohne Inhalt synchronisieren"
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr "Musikdatenbank aktivieren"
@@ -579,10 +575,6 @@ msgstr ""
 "Installiere auf dem Jellyfin Server das 'Kodi Companion' Plugin um automatische "
 "Updates der Bibliothek zu erhalten. Diese Einstellung findest du unter 'Jellyfin"
 " Addon Einstellungen > Syncronisierung > Aktiviere Kodi Companion'."
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
-msgstr "Möchtest du Serien ohne Inhalte synchronisieren?"
 
 msgctxt "#33101"
 msgid ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -230,10 +230,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr ""
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr ""
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr ""
@@ -544,10 +540,6 @@ msgstr ""
 
 msgctxt "#33099"
 msgid "Install the server plugin Kodi companion to automatically apply Jellyfin library updates at startup. This setting can be found in the add-on settings > sync options > Enable Kodi Companion."
-msgstr ""
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
 msgstr ""
 
 msgctxt "#33101"

--- a/resources/language/resource.language.es/strings.po
+++ b/resources/language/resource.language.es/strings.po
@@ -233,10 +233,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr "Activar notificaciones si el contador de actualizaciones es superior a"
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr "Sincronizar emisiones de TV vacías"
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr "Activar biblioteca de música"
@@ -564,10 +560,6 @@ msgstr ""
 "las actualizaciones de la biblioteca Jellyfin al arrancar. Esta "
 "configuración se puede encontrar en la configuración del add-on > opciones "
 "de sincronización > Habilitar Kodi Companion."
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
-msgstr "¿Quieres sincronizar las emisiones de TV vacías?"
 
 msgctxt "#33101"
 msgid "Since you are using native playback mode with music enabled, do you want to import music rating from files?"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -234,10 +234,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr "Activer la notification si le nombre de mises à jour est supérieur à"
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr "Synchroniser les séries TV vides"
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr "Activer la médiathèque musicale"
@@ -579,10 +575,6 @@ msgstr ""
 "les mises à jour de la bibliothèque Jellyfin au démarrage. Ce paramètre se "
 "trouve dans les paramètres complémentaires > options de synchronisation > "
 "Activer Kodi Companion."
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
-msgstr "Voulez-vous synchroniser les séries TV vides ?"
 
 msgctxt "#33101"
 msgid ""

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -234,10 +234,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr "Abilita notifiche se gli elementi aggiornati sono più di"
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr "Sincronizza serie TV vuote"
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr "Abilita libreria musicale"
@@ -578,10 +574,6 @@ msgstr ""
 "gli aggiornamenti della libreria Jellyfin all'avvio. Questa impostazione può "
 "essere trovata nelle impostazioni dell'add-on > opzioni di sincronizzazione>"
 " Abilita Kodi Companion."
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
-msgstr "Vorresti sincronizzare gli spettacoli vuoti?"
 
 msgctxt "#33101"
 msgid ""

--- a/resources/language/resource.language.ja/strings.po
+++ b/resources/language/resource.language.ja/strings.po
@@ -230,10 +230,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr ""
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr ""
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr ""
@@ -552,10 +548,6 @@ msgstr ""
 
 msgctxt "#33099"
 msgid "Install the server plugin Kodi companion to automatically apply Jellyfin library updates at startup. This setting can be found in the add-on settings > sync options > Enable Kodi Companion."
-msgstr ""
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
 msgstr ""
 
 msgctxt "#33101"

--- a/resources/language/resource.language.kk/strings.po
+++ b/resources/language/resource.language.kk/strings.po
@@ -230,10 +230,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr ""
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr ""
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr ""
@@ -544,10 +540,6 @@ msgstr ""
 
 msgctxt "#33099"
 msgid "Install the server plugin Kodi companion to automatically apply Jellyfin library updates at startup. This setting can be found in the add-on settings > sync options > Enable Kodi Companion."
-msgstr ""
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
 msgstr ""
 
 msgctxt "#33101"

--- a/resources/language/resource.language.ko/strings.po
+++ b/resources/language/resource.language.ko/strings.po
@@ -233,10 +233,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr "업그레이드 카운트가 이 이상이 되면 알림"
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr "빈 쇼 동기화"
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr "음악 라이브러리 활성화"
@@ -559,10 +555,6 @@ msgid "Install the server plugin Kodi companion to automatically apply Jellyfin 
 msgstr ""
 "시작시 Jellyfin 라이브러리를 자동으로 업데이트하기 위해 Kodi 컴패니언 플러그인을 설치합니다. 이 설정은 애드온 설정 -> "
 "동기화 옵션 -> Kodi 컴패니언 활성화 에서도 찾아볼 수 있습니다."
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
-msgstr "빈 쇼를 동기화하시겠습니까?"
 
 msgctxt "#33101"
 msgid "Since you are using native playback mode with music enabled, do you want to import music rating from files?"

--- a/resources/language/resource.language.nb_NO/strings.po
+++ b/resources/language/resource.language.nb_NO/strings.po
@@ -233,10 +233,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr "Aktiver varsler hvis antall oppdateringer er større enn"
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr "Synkroniser tomme serier"
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr "Aktiver musikkbibliotek"
@@ -561,10 +557,6 @@ msgstr ""
 "Installer serverpluginen Kodi companion for å automatisk hente oppdateringer "
 "i Jellyfin-bibliotekene ved oppstart. Denne innstillingen kan finnes i "
 "tilleggsinnstillinger > synkroniseringsvalg > Aktiver Kodi Companion."
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
-msgstr "Vil du synkronisere tomme serier?"
 
 msgctxt "#33101"
 msgid "Since you are using native playback mode with music enabled, do you want to import music rating from files?"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -234,10 +234,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr "Melding inschakelen als er meer updates zijn dan"
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr "Synchroniseer lege shows"
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr "Muziek bibliotheek inschakelen"
@@ -579,10 +575,6 @@ msgstr ""
 "automatisch te laten lopen bij het opstarten. Deze instellingen kan gevonden"
 " worden in de add-on instellingen > synchroniseer opties > Kodi Companion "
 "inschakelen."
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
-msgstr "Lege shows synchroniseren?"
 
 msgctxt "#33101"
 msgid ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -234,10 +234,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr "Wyświetl powiadomienie jeśli ilość aktualizacji przekroczy"
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr "Synchronizuj puste seriale"
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr "Włącz bibliotekę muzyki"
@@ -579,10 +575,6 @@ msgstr ""
 "Zainstaluj wtyczkę serwera Jellyfin \"Kodi Companion\" by automatycznie pobierać"
 " aktualizacje bazy danych. Właściwa opcja znajduje się w ustawieniach "
 "dodatku > Synchronizacja > Włącz Kodi Companion."
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
-msgstr "Synchronizować puste seriale?"
 
 msgctxt "#33101"
 msgid ""

--- a/resources/language/resource.language.pt_BR/strings.po
+++ b/resources/language/resource.language.pt_BR/strings.po
@@ -234,10 +234,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr "Ativar notificação se contagem de atualização for maior que"
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr ""
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr "Ativar biblioteca de música"
@@ -549,10 +545,6 @@ msgstr ""
 
 msgctxt "#33099"
 msgid "Install the server plugin Kodi companion to automatically apply Jellyfin library updates at startup. This setting can be found in the add-on settings > sync options > Enable Kodi Companion."
-msgstr ""
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
 msgstr ""
 
 msgctxt "#33101"

--- a/resources/language/resource.language.pt_PT/strings.po
+++ b/resources/language/resource.language.pt_PT/strings.po
@@ -233,10 +233,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr ""
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr ""
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr ""
@@ -547,10 +543,6 @@ msgstr ""
 
 msgctxt "#33099"
 msgid "Install the server plugin Kodi companion to automatically apply Jellyfin library updates at startup. This setting can be found in the add-on settings > sync options > Enable Kodi Companion."
-msgstr ""
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
 msgstr ""
 
 msgctxt "#33101"

--- a/resources/language/resource.language.ru/strings.po
+++ b/resources/language/resource.language.ru/strings.po
@@ -234,10 +234,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr "Включить уведомление, если счётчик обновлений больше чем"
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr "Синхронизировать пустые передачи"
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr "Включить музыкальную медиатеку"
@@ -555,10 +551,6 @@ msgstr "Подновить коллекции"
 msgctxt "#33099"
 msgid "Install the server plugin Kodi companion to automatically apply Jellyfin library updates at startup. This setting can be found in the add-on settings > sync options > Enable Kodi Companion."
 msgstr ""
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
-msgstr "Хотите синхронизировать пустые передачи?"
 
 msgctxt "#33101"
 msgid "Since you are using native playback mode with music enabled, do you want to import music rating from files?"

--- a/resources/language/resource.language.sk/strings.po
+++ b/resources/language/resource.language.sk/strings.po
@@ -233,10 +233,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr ""
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr "Synchronizovať prázdne seriály"
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr "Povoliť hudobnú knižnicu"
@@ -550,10 +546,6 @@ msgstr "Obnoviť boxsety"
 
 msgctxt "#33099"
 msgid "Install the server plugin Kodi companion to automatically apply Jellyfin library updates at startup. This setting can be found in the add-on settings > sync options > Enable Kodi Companion."
-msgstr ""
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
 msgstr ""
 
 msgctxt "#33101"

--- a/resources/language/resource.language.zh_Hans/strings.po
+++ b/resources/language/resource.language.zh_Hans/strings.po
@@ -233,10 +233,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr "如果更新计数大于"
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr "同步空节目"
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr "启用音乐库"
@@ -548,10 +544,6 @@ msgstr "刷新合集"
 msgctxt "#33099"
 msgid "Install the server plugin Kodi companion to automatically apply Jellyfin library updates at startup. This setting can be found in the add-on settings > sync options > Enable Kodi Companion."
 msgstr "安装服务器插件Kodi 同步 自动应用Jellyfin 库更新启动。此设置可在加载项设置 > 同步选项 > 启用 Kodi 助手中找到。"
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
-msgstr "要同步空的节目吗？"
 
 msgctxt "#33101"
 msgid "Since you are using native playback mode with music enabled, do you want to import music rating from files?"

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -230,10 +230,6 @@ msgctxt "#30507"
 msgid "Enable notification if update count is greater than"
 msgstr ""
 
-msgctxt "#30508"
-msgid "Sync empty shows"
-msgstr "同步空白节目"
-
 msgctxt "#30509"
 msgid "Enable music library"
 msgstr "启用音乐库"
@@ -545,10 +541,6 @@ msgstr ""
 msgctxt "#33099"
 msgid "Install the server plugin Kodi companion to automatically apply Jellyfin library updates at startup. This setting can be found in the add-on settings > sync options > Enable Kodi Companion."
 msgstr "安装服务器插件Kodi伴侣以在启动时自动更新Jellyfin媒体库。此设置位于插件设置 > 同步选项 > 启用Kodi伴侣"
-
-msgctxt "#33100"
-msgid "Would you like to sync empty shows?"
-msgstr "您是否想同步空节目？"
 
 msgctxt "#33101"
 msgid "Since you are using native playback mode with music enabled, do you want to import music rating from files?"

--- a/resources/lib/objects/tvshows.py
+++ b/resources/lib/objects/tvshows.py
@@ -54,13 +54,6 @@ class TVShows(KodiDb):
         obj = self.objects.map(item, 'Series')
         update = True
 
-        if not settings('syncEmptyShows.bool') and not obj['RecursiveCount']:
-
-            LOG.info("Skipping empty show %s: %s", obj['Title'], obj['Id'])
-            self.remove(obj['Id'])
-
-            return False
-
         try:
             obj['ShowId'] = e_item[0]
             obj['PathId'] = e_item[2]

--- a/resources/lib/setup.py
+++ b/resources/lib/setup.py
@@ -75,8 +75,6 @@ class Setup(object):
             LOG.info("Add-on playback: %s", settings('useDirectPaths') == "0")
             self._is_artwork_caching()
             LOG.info("Artwork caching: %s", settings('enableTextureCache.bool'))
-            self._is_empty_shows()
-            LOG.info("Sync empty shows: %s", settings('syncEmptyShows.bool'))
             self._is_rotten_tomatoes()
             LOG.info("Sync rotten tomatoes: %s", settings('syncRottenTomatoes.bool'))
 
@@ -109,11 +107,6 @@ class Setup(object):
 
         value = dialog("yesno", heading="{jellyfin}", line1=_(33117))
         settings('enableTextureCache.bool', value)
-
-    def _is_empty_shows(self):
-
-        value = dialog("yesno", heading="{jellyfin}", line1=_(33100))
-        settings('syncEmptyShows.bool', value)
 
     def _is_rotten_tomatoes(self):
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -31,7 +31,6 @@
 		<setting label="30512" id="enableTextureCache" type="bool" default="true" />
 		<setting label="30157" id="enableCoverArt" type="bool" default="true" />
 		<setting label="33116" id="compressArt" type="bool" default="false" />
-		<setting label="30508" id="syncEmptyShows" type="bool" default="false" />
 		<setting label="33187" id="syncRottenTomatoes" type="bool" default="true" />
 		<setting id="enableMusic" visible="false" default="false" />
 	</category>


### PR DESCRIPTION
Removes dialog and associated code asking the user if they want to sync empty shows and just syncs all shows regardless of episode count