### PR TITLE
Correct filepath when entering data to database

### DIFF
--- a/jellyfin_kodi/objects/movies.py
+++ b/jellyfin_kodi/objects/movies.py
@@ -175,7 +175,7 @@ class Movies(KodiDb):
             obj['Path'] = obj['Path'].replace(obj['Filename'], "")
 
         else:
-            obj['Path'] = "plugin://plugin.video.jellyfin/"
+            obj['Path'] = "plugin://plugin.video.jellyfin/%s/" % obj['LibraryId']
             params = {
                 'filename': obj['Filename'].encode('utf-8'),
                 'id': obj['Id'],

--- a/jellyfin_kodi/objects/musicvideos.py
+++ b/jellyfin_kodi/objects/musicvideos.py
@@ -163,7 +163,7 @@ class MusicVideos(KodiDb):
             obj['Path'] = obj['Path'].replace(obj['Filename'], "")
 
         else:
-            obj['Path'] = "plugin://plugin.video.jellyfin/"
+            obj['Path'] = "plugin://plugin.video.jellyfin/%s/" % obj['LibraryId']
             params = {
                 'filename': obj['Filename'].encode('utf-8'),
                 'id': obj['Id'],

--- a/jellyfin_kodi/objects/tvshows.py
+++ b/jellyfin_kodi/objects/tvshows.py
@@ -188,7 +188,7 @@ class TVShows(KodiDb):
                 obj['TopLevel'] = "%s\\" % dirname(dirname(obj['Path']))
             else:
                 obj['Path'] = "%s/" % obj['Path']
-                obj['TopLevel'] = "%s/" % dirname(dirname(obj['Path']))
+                obj['TopLevel'] = "plugin://plugin.video.jellyfin/%s/" % obj['LibraryId']
 
             if not validate(obj['Path']):
                 raise Exception("Failed to validate path. User stopped.")

--- a/jellyfin_kodi/objects/tvshows.py
+++ b/jellyfin_kodi/objects/tvshows.py
@@ -188,12 +188,12 @@ class TVShows(KodiDb):
                 obj['TopLevel'] = "%s\\" % dirname(dirname(obj['Path']))
             else:
                 obj['Path'] = "%s/" % obj['Path']
-                obj['TopLevel'] = "plugin://plugin.video.jellyfin/%s/" % obj['LibraryId']
+                obj['TopLevel'] = "plugin://plugin.video.jellyfin/"
 
             if not validate(obj['Path']):
                 raise Exception("Failed to validate path. User stopped.")
         else:
-            obj['TopLevel'] = "plugin://plugin.video.jellyfin/"
+            obj['TopLevel'] = "plugin://plugin.video.jellyfin/%s/" % obj['LibraryId']
             obj['Path'] = "%s%s/" % (obj['TopLevel'], obj['Id'])
 
     @stop()


### PR DESCRIPTION
Fixes #53 

Without including the libraryId in the path, it just kept overwriting the top level with whatever library had most recently synced