### PR TITLE
Remove emby endpoints from api calls

### DIFF
--- a/jellyfin_kodi/database/__init__.py
+++ b/jellyfin_kodi/database/__init__.py
@@ -63,6 +63,15 @@ class Database(object):
             jellyfin_tables(self.cursor)
             self.conn.commit()
 
+        # Migration for #162
+        if self.db_file == 'music':
+            query = self.conn.execute('SELECT * FROM path WHERE strPath LIKE "%/emby/%"')
+            contents = query.fetchall()
+            if contents:
+                for item in contents:
+                    newPath = item[1].replace('/emby/', '/')
+                    self.conn.execute('UPDATE path SET strPath = "{}" WHERE idPath = "{}"'.format(newPath, item[0]))
+
         return self
 
     def _get_database(self, path, silent=False):

--- a/jellyfin_kodi/dialogs/usersconnect.py
+++ b/jellyfin_kodi/dialogs/usersconnect.py
@@ -97,4 +97,4 @@ class UsersConnect(xbmcgui.WindowXMLDialog):
 
     def _get_user_artwork(self, user_id, item_type):
         # Load user information set by UserClient
-        return "%s/emby/Users/%s/Images/%s?Format=original" % (self.server, user_id, item_type)
+        return "%s/Users/%s/Images/%s?Format=original" % (self.server, user_id, item_type)

--- a/jellyfin_kodi/downloader.py
+++ b/jellyfin_kodi/downloader.py
@@ -28,7 +28,7 @@ def get_jellyfinserver_url(handler):
         handler = handler[1:]
         LOG.info("handler starts with /: %s", handler)
 
-    return "{server}/emby/%s" % handler
+    return "{server}/%s" % handler
 
 
 def browse_info():

--- a/jellyfin_kodi/helper/api.py
+++ b/jellyfin_kodi/helper/api.py
@@ -228,7 +228,7 @@ class API(object):
 
         ''' Get jellyfin user profile picture.
         '''
-        return "%s/emby/Users/%s/Images/Primary?Format=original" % (self.server, user_id)
+        return "%s/Users/%s/Images/Primary?Format=original" % (self.server, user_id)
 
     def get_people_artwork(self, people):
 
@@ -306,7 +306,7 @@ class API(object):
 
         for index, tag in enumerate(tags):
 
-            artwork = "%s/emby/Items/%s/Images/Backdrop/%s?Format=original&Tag=%s%s" % (self.server, item_id, index, tag, (query or ""))
+            artwork = "%s/Items/%s/Images/Backdrop/%s?Format=original&Tag=%s%s" % (self.server, item_id, index, tag, (query or ""))
             backdrops.append(artwork)
 
         return backdrops
@@ -318,7 +318,7 @@ class API(object):
         if item_id is None:
             return ""
 
-        url = "%s/emby/Items/%s/Images/%s/0?Format=original" % (self.server, item_id, image)
+        url = "%s/Items/%s/Images/%s/0?Format=original" % (self.server, item_id, image)
 
         if tag is not None:
             url += "&Tag=%s" % tag

--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -254,10 +254,10 @@ class PlayUtils(object):
 
             video_type = 'live' if source['Protocol'] == 'LiveTV' else 'master'
             base = base.replace('stream' if 'stream' in base else 'master', video_type, 1)
-            self.info['Path'] = "%s/emby%s?%s" % (self.info['ServerAddress'], base, params)
+            self.info['Path'] = "%s/%s?%s" % (self.info['ServerAddress'], base, params)
             self.info['Path'] += "&maxWidth=%s&maxHeight=%s" % (self.get_resolution())
         else:
-            self.info['Path'] = "%s/emby%s" % (self.info['ServerAddress'], source['TranscodingUrl'])
+            self.info['Path'] = "%s/%s" % (self.info['ServerAddress'], source['TranscodingUrl'])
 
         return self.info['Path']
 
@@ -274,14 +274,14 @@ class PlayUtils(object):
         self.info['Method'] = "DirectStream"
 
         if self.item['Type'] == "Audio":
-            self.info['Path'] = "%s/emby/Audio/%s/stream.%s?static=true&api_key=%s" % (
+            self.info['Path'] = "%s/Audio/%s/stream.%s?static=true&api_key=%s" % (
                 self.info['ServerAddress'],
                 self.item['Id'],
                 source.get('Container', "mp4").split(',')[0],
                 self.info['Token']
             )
         else:
-            self.info['Path'] = "%s/emby/Videos/%s/stream?static=true&MediaSourceId=%s&api_key=%s" % (
+            self.info['Path'] = "%s/Videos/%s/stream?static=true&MediaSourceId=%s&api_key=%s" % (
                 self.info['ServerAddress'],
                 self.item['Id'],
                 source['Id'],
@@ -474,7 +474,7 @@ class PlayUtils(object):
                 index = stream['Index']
 
                 if 'DeliveryUrl' in stream and stream['DeliveryUrl'].lower().startswith('/videos'):
-                    url = "%s/emby%s" % (self.info['ServerAddress'], stream['DeliveryUrl'])
+                    url = "%s/%s" % (self.info['ServerAddress'], stream['DeliveryUrl'])
                 else:
                     url = self.get_subtitles(source, stream, index)
 
@@ -630,9 +630,9 @@ class PlayUtils(object):
     def get_subtitles(self, source, stream, index):
 
         if stream['IsTextSubtitleStream'] and 'DeliveryUrl' in stream and stream['DeliveryUrl'].lower().startswith('/videos'):
-            url = "%s/emby%s" % (self.info['ServerAddress'], stream['DeliveryUrl'])
+            url = "%s/%s" % (self.info['ServerAddress'], stream['DeliveryUrl'])
         else:
-            url = "%s/emby/Videos/%s/%s/Subtitles/%s/Stream.%s?api_key=%s" % (
+            url = "%s/Videos/%s/%s/Subtitles/%s/Stream.%s?api_key=%s" % (
                 self.info['ServerAddress'],
                 self.item['Id'],
                 source['Id'],

--- a/jellyfin_kodi/jellyfin/api.py
+++ b/jellyfin_kodi/jellyfin/api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 def jellyfin_url(client, handler):
-    return "%s/emby/%s" % (client.config.data['auth.server'], handler)
+    return "%s/%s" % (client.config.data['auth.server'], handler)
 
 
 def basic_info():

--- a/jellyfin_kodi/jellyfin/connection_manager.py
+++ b/jellyfin_kodi/jellyfin/connection_manager.py
@@ -140,7 +140,7 @@ class ConnectionManager(object):
             LOG.exception(error)
             LOG.error("connectToAddress %s failed", address)
             return { 'State': CONNECTION_STATE['Unavailable'] }
-           
+
 
     def connect_to_server(self, server, options={}):
 
@@ -155,7 +155,7 @@ class ConnectionManager(object):
 
         except Exception as e:
             LOG.info("Failing server connection. ERROR msg: {}".format(e))
-            return { 'State': CONNECTION_STATE['Unavailable'] }            
+            return { 'State': CONNECTION_STATE['Unavailable'] }
 
     def connect(self, options={}):
         LOG.info("Begin connect")
@@ -183,7 +183,7 @@ class ConnectionManager(object):
         return self.client.jellyfin.get_public_users()
 
     def get_jellyfin_url(self, base, handler):
-        return "%s/emby/%s" % (base, handler)
+        return "%s/%s" % (base, handler)
 
     def _request_url(self, request, headers=True):
 
@@ -328,7 +328,7 @@ class ConnectionManager(object):
                 'Id': found_server['Id'],
                 'address': server or found_server['Address'],
                 'Name': found_server['Name']
-            } 
+            }
 
             servers.append(info)
         else:
@@ -451,7 +451,7 @@ class ConnectionManager(object):
         if system_info.get('address'):
             server['address'] = system_info['address']
 
-        ## Finish updating server info 
+        ## Finish updating server info
 
     def _on_authenticated(self, result, options={}):
 

--- a/jellyfin_kodi/jellyfin/http.py
+++ b/jellyfin_kodi/jellyfin/http.py
@@ -167,7 +167,7 @@ class HTTP(object):
     def _request(self, data):
 
         if 'url' not in data:
-            data['url'] = "%s/emby/%s" % (self.config.data['auth.server'], data.pop('handler', ""))
+            data['url'] = "%s/%s" % (self.config.data['auth.server'], data.pop('handler', ""))
 
         self._get_header(data)
         data['timeout'] = data.get('timeout') or self.config.data['http.timeout']

--- a/jellyfin_kodi/objects/music.py
+++ b/jellyfin_kodi/objects/music.py
@@ -329,7 +329,7 @@ class Music(KodiDb):
 
         else:
             server_address = self.server.auth.get_server_info(self.server.auth.server_id)['address']
-            obj['Path'] = "%s/emby/Audio/%s/" % (server_address, obj['Id'])
+            obj['Path'] = "%s/Audio/%s/" % (server_address, obj['Id'])
             obj['Filename'] = "stream.%s?static=true" % obj['Container']
 
     def song_artist_discography(self, obj):


### PR DESCRIPTION
Removes all references to `/emby/` in the api calls, and provides a migration for the music database because those values were previously included in the URL.

Before migration:
```
sqlite> select * from path;
1|http://192.168.0.200:8097/emby/Audio/4f8e9b07537fcec02d8acbfe8fbe6195/|
2|http://192.168.0.200:8097/emby/Audio/a29a96e5338e03511711cb06f5fe9797/|
3|http://192.168.0.200:8097/emby/Audio/d7db5f66f4aea898e25c61d39d528a76/|
4|http://192.168.0.200:8097/emby/Audio/974951ed0d5619333f2869069079816f/|
5|http://192.168.0.200:8097/emby/Audio/02b2a4177fb995094681fe1008eceff5/|
```

After migration:
```
sqlite> select * from path;
1|http://192.168.0.200:8097/Audio/4f8e9b07537fcec02d8acbfe8fbe6195/|
2|http://192.168.0.200:8097/Audio/a29a96e5338e03511711cb06f5fe9797/|
3|http://192.168.0.200:8097/Audio/d7db5f66f4aea898e25c61d39d528a76/|
4|http://192.168.0.200:8097/Audio/974951ed0d5619333f2869069079816f/|
5|http://192.168.0.200:8097/Audio/02b2a4177fb995094681fe1008eceff5/|
```
Edit: Closes #162 