### PR TITLE
Fix link to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The add-on supports a hybrid approach. You can decide which Jellyfin libraries t
 
 ### Install Jellyfin for Kodi
 
-Detailed installation instructions can be found in the [Jellyfin Client Documentation](https://docs.jellyfin.org/general/clients/clients.html#jellyfin-for-kodi).
+Detailed installation instructions can be found in the [Jellyfin Client Documentation](https://docs.jellyfin.org/general/clients/installing-kodi.html).
 
 <!-- Get started with the [wiki guide](https://github.com/MediaBrowser/plugin.video.emby/wiki) -->
 


### PR DESCRIPTION
Installation docs moved to a new location again