### PR TITLE
Move the RemoteAddress check

### DIFF
--- a/jellyfin_kodi/database/__init__.py
+++ b/jellyfin_kodi/database/__init__.py
@@ -404,15 +404,15 @@ def get_credentials():
     # Migration for #145
     # TODO: CLEANUP for 1.0.0 release
     for server in credentials['Servers']:
+        # Functionality removed in #60
+        if 'RemoteAddress' in server:
+            del server['RemoteAddress']
         if 'ManualAddress' in server:
             server['address'] = server['ManualAddress']
             del server['ManualAddress']
             # If manual is present, local should always be here, but better to be safe
             if 'LocalAddress' in server:
                 del server['LocalAddress']
-            # Functionality removed in #60
-            if 'RemoteAddress' in server:
-                del server['RemoteAddress']
         elif 'LocalAddress' in server:
             server['address'] = server['LocalAddress']
             del server['LocalAddress']


### PR DESCRIPTION
Moves the remote address check so that it will always get ran.  Cleans up any lingering user configs from before we removed the WAN IP dependency.