### PR TITLE
Fix kodi 19 websocket control

### DIFF
--- a/jellyfin_kodi/jellyfin/websocket.py
+++ b/jellyfin_kodi/jellyfin/websocket.py
@@ -545,8 +545,8 @@ class WebSocket(object):
             return False
         result = result.lower()
 
-        value = key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-        hashed = base64.encodestring(hashlib.sha1(value).digest()).strip().lower()
+        value = key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11".encode()
+        hashed = base64.encodestring(hashlib.sha1(value).digest()).strip().lower().decode()
         return hashed == result
 
     def _read_headers(self):
@@ -795,11 +795,11 @@ class WebSocket(object):
     def _recv_line(self):
         line = []
         while True:
-            c = self._recv(1)
+            c = self._recv(1).decode()
             line.append(c)
             if c == "\n":
                 break
-        return b"".join(line)
+        return "".join(line)
 
 
 class WebSocketApp(object):

--- a/jellyfin_kodi/jellyfin/websocket.py
+++ b/jellyfin_kodi/jellyfin/websocket.py
@@ -545,7 +545,9 @@ class WebSocket(object):
             return False
         result = result.lower()
 
-        value = key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11".encode()
+        # https://tools.ietf.org/html/rfc6455#page-6
+        magic_string = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11".encode()
+        value = key +  magic_string
         hashed = base64.encodestring(hashlib.sha1(value).digest()).strip().lower().decode()
         return hashed == result
 


### PR DESCRIPTION
Add encode/decode shenanigans to make sure string/byte types match across python 2 and python 3.  Fixes remote control from the Web UI in Kodi 19 installs.

Closes #183 