### PR TITLE
Obj error

### DIFF
--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -680,13 +680,13 @@ class UserDataWorker(threading.Thread):
                 elif item['Type'] in ['Series', 'Season', 'Episode']:
                     obj = TVShows(self.args[0], jellyfindb, kodidb, self.args[1]).userdata(item)
                 elif item['Type'] == 'MusicAlbum':
-                        obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).album
+                    obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).album
                 elif item['Type'] == 'MusicArtist':
-                        obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).artist
+                    obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).artist
                 elif item['Type'] == 'AlbumArtist':
-                        obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).albumartist
+                    obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).albumartist
                 elif item['Type'] == 'Audio':
-                        obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).song
+                    obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).song
 
                 try:
                     obj(item)

--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -679,6 +679,14 @@ class UserDataWorker(threading.Thread):
                     obj = Movies(self.args[0], jellyfindb, kodidb, self.args[1]).userdata(item)
                 elif item['Type'] in ['Series', 'Season', 'Episode']:
                     obj = TVShows(self.args[0], jellyfindb, kodidb, self.args[1]).userdata(item)
+                elif item['Type'] == 'MusicAlbum':
+                        obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).album
+                elif item['Type'] == 'MusicArtist':
+                        obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).artist
+                elif item['Type'] == 'AlbumArtist':
+                        obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).albumartist
+                elif item['Type'] == 'Audio':
+                        obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).song
 
                 try:
                     obj(item)


### PR DESCRIPTION
Gets rid of this annoying error in the logs:
```
NOTICE: JELLYFIN.library -> ERROR::jellyfin_kodi/library.py:688 local variable 'obj' referenced before assignment
 Traceback (most recent call last):
   File "jellyfin_kodi/library.py", line 683, in run
     obj(item)
 UnboundLocalError: local variable 'obj' referenced before assignment
```

Not sure why these other item types were never being mapped here before