### PR TITLE
Move the responsibility of the maximum number of threads to the UI.

### DIFF
--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -23,7 +23,7 @@ from jellyfin import Jellyfin
 ##################################################################################################
 
 LOG = logging.getLogger("JELLYFIN." + __name__)
-LIMIT = min(int(settings('limitIndex') or 50), 50)
+LIMIT = int(settings('limitIndex') or 15)
 DTHREADS = int(settings('limitThreads') or 3)
 MEDIA = {
     'Movie': Movies,

--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -139,7 +139,8 @@ class Library(threading.Thread):
 
         if not self.player.isPlayingVideo() or settings('syncDuringPlay.bool') or xbmc.getCondVisibility('VideoPlayer.Content(livetv)'):
 
-            self.worker_downloads()
+            while self.worker_downloads():
+                pass
             self.worker_sort()
 
             self.worker_updates()
@@ -225,6 +226,7 @@ class Library(threading.Thread):
 
         ''' Get items from jellyfin and place them in the appropriate queues.
         '''
+        added_threads = False
         for queue in ((self.updated_queue, self.updated_output), (self.userdata_queue, self.userdata_output)):
             if queue[0].qsize() and len(self.download_threads) < DTHREADS:
 
@@ -232,6 +234,8 @@ class Library(threading.Thread):
                 new_thread.start()
                 LOG.info("-->[ q:download/%s ]", id(new_thread))
                 self.download_threads.append(new_thread)
+                added_threads = True
+        return added_threads
 
     def worker_sort(self):
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -25,8 +25,8 @@
 		<setting label="30511" id="useDirectPaths" type="enum" lvalues="33036|33037" default="1" />
 
 		<setting label="33175" type="lsep" />
-		<setting label="30515" id="limitIndex" type="number" default="15" option="int" />
-		<setting label="33174" id="limitThreads" type="number" default="3" option="int" />
+		<setting label="30515" id="limitIndex" type="slider" default="15" range="1, 1, 100" option="int" />
+		<setting label="33174" id="limitThreads" type="slider" default="3" range="1, 1, 50" option="int" />
 		<setting label="33176" type="lsep" />
 		<setting label="30512" id="enableTextureCache" type="bool" default="true" />
 		<setting label="30157" id="enableCoverArt" type="bool" default="true" />


### PR DESCRIPTION
Previously the user was able to set any number to limitThreads UI component but internally that was reduced to be a maximum of 50 which is deceiving to the user. Set this is set as a boundary in the UI.
    
This also fixes a bug that the user could set the number of threads to zero which follows from GIGO; but let the UI assist by placing a min number of threads to 1.
