### PR TITLE
Parallelize multiple http GETs

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -10,6 +10,7 @@
     <import addon="script.module.six" />
     <import addon="script.module.kodi-six" />
     <import addon="script.module.addon.signals" version="0.0.1"/>
+    <import addon="script.module.futures" version="2.2.0"/>
   </requires>
   <extension    point="xbmc.python.pluginsource"
                 library="default.py">

--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -138,8 +138,7 @@ class Library(threading.Thread):
 
         if not self.player.isPlayingVideo() or settings('syncDuringPlay.bool') or xbmc.getCondVisibility('VideoPlayer.Content(livetv)'):
 
-            while self.worker_downloads():
-                pass
+            self.worker_downloads()
             self.worker_sort()
 
             self.worker_updates()
@@ -225,7 +224,6 @@ class Library(threading.Thread):
 
         ''' Get items from jellyfin and place them in the appropriate queues.
         '''
-        added_threads = False
         for queue in ((self.updated_queue, self.updated_output), (self.userdata_queue, self.userdata_output)):
             if queue[0].qsize() and len(self.download_threads) < DTHREADS:
 
@@ -233,8 +231,6 @@ class Library(threading.Thread):
                 new_thread.start()
                 LOG.info("-->[ q:download/%s ]", id(new_thread))
                 self.download_threads.append(new_thread)
-                added_threads = True
-        return added_threads
 
     def worker_sort(self):
 


### PR DESCRIPTION
Added ThreadPoolExecutor and used to process GET requests in multiple
threads which enables chunks of data to always be available for
processing. Processing of the data can happen as soon as the first chunk
arrives.

Refactored the code to help implement. The idea is the "params" are
built in batch and passed to the thread pool which get the actual
results.

Removed previous usage of DTHREADS in favour of this implementation.