### PR TITLE
Simplify request interface

### DIFF
--- a/jellyfin_kodi/downloader.py
+++ b/jellyfin_kodi/downloader.py
@@ -41,21 +41,21 @@ def browse_info():
     )
 
 
-def _http(action, url, request={}, server_id=None):
-    request.update({'url': url, 'type': action})
-    return Jellyfin(server_id).http.request(request)
-
-
 def _get(handler, params=None, server_id=None):
-    return _http("GET", get_jellyfinserver_url(handler), {'params': params}, server_id)
-
+    url = get_jellyfinserver_url(handler)
+    jf = Jellyfin(server_id)
+    return jf.http.REQUEST(url, "GET", params)
 
 def _post(handler, json=None, params=None, server_id=None):
-    return _http("POST", get_jellyfinserver_url(handler), {'params': params, 'json': json}, server_id)
+    url = get_jellyfinserver_url(handler)
+    jf = Jellyfin(server_id)
+    return jf.http.REQUEST(url, "POST", params, json)
 
 
 def _delete(handler, params=None, server_id=None):
-    return _http("DELETE", get_jellyfinserver_url(handler), {'params': params}, server_id)
+    url = get_jellyfinserver_url(handler)
+    jf = Jellyfin(server_id)
+    return jf.http.REQUEST(url, "DELETE", params)
 
 
 def validate_view(library_id, item_id):
@@ -314,17 +314,14 @@ class GetItemWorker(threading.Thread):
 
                     return
 
-                request = {
-                    'type': "GET",
-                    'handler': "Users/{UserId}/Items",
-                    'params': {
-                        'Ids': ','.join(str(x) for x in item_ids),
-                        'Fields': api.info()
-                    }
+                url = self.server.http.get_handler_url("Users/{UserId}/Items")
+                params = {
+                    'Ids': ','.join(str(x) for x in item_ids),
+                    'Fields': api.info()
                 }
 
                 try:
-                    result = self.server.http.request(request, s)
+                    result = self.server.http.REQUEST(url, "GET", params, s)
 
                     for item in result['Items']:
 

--- a/jellyfin_kodi/downloader.py
+++ b/jellyfin_kodi/downloader.py
@@ -44,18 +44,18 @@ def browse_info():
 def _get(handler, params=None, server_id=None):
     url = get_jellyfinserver_url(handler)
     jf = Jellyfin(server_id)
-    return jf.http.REQUEST(url, "GET", params)
+    return jf.http.request_url(url, "GET", params)
 
 def _post(handler, json=None, params=None, server_id=None):
     url = get_jellyfinserver_url(handler)
     jf = Jellyfin(server_id)
-    return jf.http.REQUEST(url, "POST", params, json)
+    return jf.http.request_url(url, "POST", params, json)
 
 
 def _delete(handler, params=None, server_id=None):
     url = get_jellyfinserver_url(handler)
     jf = Jellyfin(server_id)
-    return jf.http.REQUEST(url, "DELETE", params)
+    return jf.http.request_url(url, "DELETE", params)
 
 
 def validate_view(library_id, item_id):
@@ -321,7 +321,7 @@ class GetItemWorker(threading.Thread):
                 }
 
                 try:
-                    result = self.server.http.REQUEST(url, "GET", params, s)
+                    result = self.server.http.request_url(url, "GET", params, s)
 
                     for item in result['Items']:
 

--- a/jellyfin_kodi/jellyfin/api.py
+++ b/jellyfin_kodi/jellyfin/api.py
@@ -36,19 +36,17 @@ class API(object):
     def __init__(self, client, *args, **kwargs):
         self.client = client
 
-    def _http(self, action, url, request={}):
-        request.update({'type': action, 'handler': url})
-
-        return self.client.request(request)
-
     def _get(self, handler, params=None):
-        return self._http("GET", handler, {'params': params})
+        url = self.client.get_handler_url(handler)
+        return self.client.REQUEST(url, "GET", params)
 
     def _post(self, handler, json=None, params=None):
-        return self._http("POST", handler, {'params': params, 'json': json})
+        url = self.client.get_handler_url(handler)
+        return self.client.REQUEST(url, "POST", params, json)
 
     def _delete(self, handler, params=None):
-        return self._http("DELETE", handler, {'params': params})
+        url = self.client.get_handler_url(handler)
+        return self.client.REQUEST(url, "DELETE", params)
 
     #################################################################################################
 

--- a/jellyfin_kodi/jellyfin/api.py
+++ b/jellyfin_kodi/jellyfin/api.py
@@ -38,15 +38,15 @@ class API(object):
 
     def _get(self, handler, params=None):
         url = self.client.get_handler_url(handler)
-        return self.client.REQUEST(url, "GET", params)
+        return self.client.request_url(url, "GET", params)
 
     def _post(self, handler, json=None, params=None):
         url = self.client.get_handler_url(handler)
-        return self.client.REQUEST(url, "POST", params, json)
+        return self.client.request_url(url, "POST", params, json)
 
     def _delete(self, handler, params=None):
         url = self.client.get_handler_url(handler)
-        return self.client.REQUEST(url, "DELETE", params)
+        return self.client.request_url(url, "DELETE", params)
 
     #################################################################################################
 

--- a/jellyfin_kodi/jellyfin/connection_manager.py
+++ b/jellyfin_kodi/jellyfin/connection_manager.py
@@ -199,7 +199,7 @@ class ConnectionManager(object):
             data['json'] = json
 
 
-        timeput = timeout or self.timeout
+        timeout = timeout or self.timeout
         data['timeout'] = timeout
         if additional_headers:
             extra_headers = self._get_headers(data_type)

--- a/jellyfin_kodi/jellyfin/connection_manager.py
+++ b/jellyfin_kodi/jellyfin/connection_manager.py
@@ -182,19 +182,12 @@ class ConnectionManager(object):
     def get_jellyfin_url(self, base, handler):
         return "%s/%s" % (base, handler)
 
-    def _add_app_info(self):
-        return "%s/%s" % (self.config.data['app.name'], self.config.data['app.version'])
-
-    def _get_headers(self, data_type):
-        headers = {}
-
-        if data_type == "json":
-            headers['Accept'] = "application/json"
-
-        headers['X-Application'] = self._add_app_info()
-        headers['Content-type'] = 'application/x-www-form-urlencoded; charset=UTF-8'
-
-        return headers
+    def _get_headers(self):
+        return {
+            'Accept':         "application/json",
+            'X-Application':  "%s/%s" % (self.config.data['app.name'], self.config.data['app.version']),
+            'Content-type':   'application/x-www-form-urlencoded; charset=UTF-8',
+        }
 
     def _connect_to_servers(self, servers, options):
 
@@ -227,7 +220,7 @@ class ConnectionManager(object):
         url = self.get_jellyfin_url(url, "system/info/public")
         LOG.info("tryConnect url: %s", url)
         timeout = timeout or self.timeout
-        headers = self._get_headers('json')
+        headers = self._get_headers()
 
         try:
             return self.http.REQUEST(url, "GET", headers=headers, \
@@ -404,7 +397,7 @@ class ConnectionManager(object):
 
         try:
             url = self.get_jellyfin_url(server['address'], "System/Info")
-            headers = self._get_headers('json')
+            headers = self._get_headers()
             headers['X-MediaBrowser-Token'] = server['AccessToken']
 
             system_info = self.http.REQUEST(url, "GET", headers=headers, \

--- a/jellyfin_kodi/jellyfin/connection_manager.py
+++ b/jellyfin_kodi/jellyfin/connection_manager.py
@@ -151,7 +151,6 @@ class ConnectionManager(object):
             return self._after_connect_validated(server, credentials, result, True, options)
 
         except Exception as e:
-            raise
             LOG.info("Failing server connection. ERROR msg: {}".format(e))
             return { 'State': CONNECTION_STATE['Unavailable'] }
 

--- a/jellyfin_kodi/jellyfin/connection_manager.py
+++ b/jellyfin_kodi/jellyfin/connection_manager.py
@@ -104,7 +104,7 @@ class ConnectionManager(object):
                 'Username': username,
                 'Pw': password or ""
             }
-            result = self.http.REQUEST(url, "POST", json=json, timeout=self.timeout)
+            result = self.http.request_url(url, "POST", json=json, timeout=self.timeout)
         except Exception as error:  # Failed to login
             LOG.exception(error)
             return False
@@ -223,7 +223,7 @@ class ConnectionManager(object):
         headers = self._get_headers()
 
         try:
-            return self.http.REQUEST(url, "GET", headers=headers, \
+            return self.http.request_url(url, "GET", headers=headers, \
                     timeout=timeout, retry=False)
         except Exception as error:
             LOG.exception(error)
@@ -400,7 +400,7 @@ class ConnectionManager(object):
             headers = self._get_headers()
             headers['X-MediaBrowser-Token'] = server['AccessToken']
 
-            system_info = self.http.REQUEST(url, "GET", headers=headers, \
+            system_info = self.http.request_url(url, "GET", headers=headers, \
                     verify=options.get('ssl'), timeout=self.timeout)
 
             self._update_server_info(server, system_info)

--- a/jellyfin_kodi/jellyfin/connection_manager.py
+++ b/jellyfin_kodi/jellyfin/connection_manager.py
@@ -104,8 +104,7 @@ class ConnectionManager(object):
                 'Username': username,
                 'Pw': password or ""
             }
-            result = self._REQUEST_URL(url, "POST", json=json, additional_headers=False)
-
+            result = self.http.REQUEST(url, "POST", json=json, timeout=self.timeout)
         except Exception as error:  # Failed to login
             LOG.exception(error)
             return False
@@ -184,27 +183,14 @@ class ConnectionManager(object):
     def get_jellyfin_url(self, base, handler):
         return "%s/%s" % (base, handler)
 
-    def _REQUEST_URL(self, url, type, data_type=None, timeout=None, verify=None, retry=None,
+    def _REQUEST_URL(self, url, type, data_type=None, timeout=None, verify=None, retry=5,
             headers={}, json=None, additional_headers=True):
-        data = {
-            'type': type,
-            'url': url,
-            'headers': headers,
-        }
-        if verify is not None:
-            data['verify'] = verify
-        if retry is not None:
-            data['retry'] = retry
-        if json is not None:
-            data['json'] = json
-
+        headers = dict(headers)
 
         timeout = timeout or self.timeout
-        data['timeout'] = timeout
         if additional_headers:
             extra_headers = self._get_headers(data_type)
-            data['headers'].update(extra_headers)
-            headers = data['headers']
+            headers.update(extra_headers)
 
         try:
             return self.http.REQUEST(url, type, json=json, headers=headers, \

--- a/jellyfin_kodi/jellyfin/connection_manager.py
+++ b/jellyfin_kodi/jellyfin/connection_manager.py
@@ -415,7 +415,7 @@ class ConnectionManager(object):
         # Update configs
         self.config.data['auth.server'] = server['address']
         self.config.data['auth.server-name'] = server['Name']
-        self.config.data['auth.server=id'] = server['Id']
+        self.config.data['auth.server-id'] = server['Id']
         self.config.data['auth.ssl'] = options.get('ssl', self.config.data['auth.ssl'])
 
         result = {

--- a/jellyfin_kodi/jellyfin/connection_manager.py
+++ b/jellyfin_kodi/jellyfin/connection_manager.py
@@ -191,24 +191,24 @@ class ConnectionManager(object):
             'url': url,
             'headers': headers,
         }
-        if timeout is not None:
-            data['timeout'] = timeout
         if verify is not None:
             data['verify'] = verify
         if retry is not None:
             data['retry'] = retry
         if json is not None:
             data['json'] = json
-        return self._request_url(data, data_type, timeout, additional_headers=additional_headers)
 
-    def _request_url(self, data, data_type=None, timeout=None, additional_headers=True):
-        data['timeout'] = timeout or self.timeout
+
+        timeput = timeout or self.timeout
+        data['timeout'] = timeout
         if additional_headers:
-            headers = self._get_headers(data_type)
-            data.setdefault('headers', {}).update(headers)
+            extra_headers = self._get_headers(data_type)
+            data['headers'].update(extra_headers)
+            headers = data['headers']
 
         try:
-            return self.http.request(data)
+            return self.http.REQUEST(url, type, json=json, headers=headers, \
+                    verify=verify, timeout=timeout, retry=retry)
         except Exception as error:
             LOG.exception(error)
             raise

--- a/jellyfin_kodi/jellyfin/http.py
+++ b/jellyfin_kodi/jellyfin/http.py
@@ -64,13 +64,24 @@ class HTTP(object):
 
         return string
 
-    def REQUEST(self, url, type, params=None, json=None, session=None):
-        request = {'url': url, 'type': type}
+    def REQUEST(self, url, type, params=None, json=None, session=None, \
+                    headers=None, verify=None, timeout=None, retry=None):
+        data = {'url': url, 'type': type}
         if params is not None:
-            request['params'] = params
+            data['params'] = params
         if json is not None:
-            request['json'] = json
-        return self.request(request, session)
+            data['json'] = json
+        if headers is not None:
+            data['headers'] = headers
+        if timeout is not None:
+            data['timeout'] = timeout
+        if verify is not None:
+            data['verify'] = verify
+        if retry is not None:
+            data['retry'] = retry
+        if json is not None:
+            data['json'] = json
+        return self.request(data, session)
 
 
     def get_handler_url(self, handler):

--- a/jellyfin_kodi/jellyfin/http.py
+++ b/jellyfin_kodi/jellyfin/http.py
@@ -204,8 +204,8 @@ class HTTP(object):
             }
 
         if 'x-emby-authorization' not in headers:
-            xxx = self._authorization(config)
-            headers.update(xxx)
+            auth_headers = self._authorization(config)
+            headers.update(auth_headers)
 
         return headers
 
@@ -220,10 +220,10 @@ class HTTP(object):
 
         if config.get('auth.token') and config.get('auth.user_id'):
             auth += ', UserId=%s' % config.get('auth.user_id')
-            xxx = {'x-emby-authorization': auth, 'X-MediaBrowser-Token': config.get('auth.token')}
+            headers = {'x-emby-authorization': auth, 'X-MediaBrowser-Token': config.get('auth.token')}
         else:
-            xxx = {'x-emby-authorization': auth}
-        return xxx
+            headers = {'x-emby-authorization': auth}
+        return headers
 
     def _requests(self, session, action, **kwargs):
 

--- a/jellyfin_kodi/jellyfin/http.py
+++ b/jellyfin_kodi/jellyfin/http.py
@@ -71,7 +71,7 @@ class HTTP(object):
         return "%s/%s" % (server, handler)
 
 
-    def REQUEST(self, url, type, params=None, json=None, session=None, \
+    def request_url(self, url, type, params=None, json=None, session=None, \
                     headers={}, verify=None, timeout=None, retry=5):
         config = self.config.data
 

--- a/jellyfin_kodi/jellyfin/http.py
+++ b/jellyfin_kodi/jellyfin/http.py
@@ -64,6 +64,20 @@ class HTTP(object):
 
         return string
 
+    def REQUEST(self, url, type, params=None, json=None, session=None):
+        request = {'url': url, 'type': type}
+        if params is not None:
+            request['params'] = params
+        if json is not None:
+            request['json'] = json
+        return self.request(request, session)
+
+
+    def get_handler_url(self, handler):
+        server = self.config.data.get("auth.server", "")
+        return "%s/%s" % (server, handler)
+
+
     def request(self, data, session=None):
 
         ''' Give a chance to retry the connection. Jellyfin sometimes can be slow to answer back


### PR DESCRIPTION
Hi,

During optimization investigations, I was coming to the point where the network was my biggest bottleneck. Attempting to deduce where could be a chance for optimization was daunting as the interface to http.request was cumbersome. The author had decided to pass in a chunk of data in a dictionary for what appears to be a design decision for extensibility and abstraction for many different types of calls (ie. login, authentication and general server queries)
I was unable to reason if parameters were purely "in" parameters or "in/out" parameters and such was bound to the data structures that were already in place.

This PR is only a refactorization (sorry). The main aim to use pythons inbuilt parameter passing mechanism instead of an ad-hoc dictionary. It will enable me to investigate potential optimizations in the http/networking code for general server queries while reducing the risk that authentication (say) will be broken.

