### PR TITLE
Reduce execute and fetch one calls

### DIFF
--- a/jellyfin_kodi/objects/kodi/kodi.py
+++ b/jellyfin_kodi/objects/kodi/kodi.py
@@ -40,11 +40,6 @@ class Kodi(object):
 
         return self.cursor.fetchone()[0] + 1
 
-    def create_entry_person(self):
-        self.cursor.execute(QU.create_person)
-
-        return self.cursor.fetchone()[0] + 1
-
     def create_entry_genre(self):
         self.cursor.execute(QU.create_genre)
 
@@ -164,8 +159,8 @@ class Kodi(object):
 
     def add_person(self, *args):
 
-        person_id = self.create_entry_person()
-        self.cursor.execute(QU.add_person, (person_id,) + args)
+        self.cursor.execute(QU.add_person, args)
+        return self.cursor.lastrowid
 
         return person_id
 

--- a/jellyfin_kodi/objects/kodi/kodi.py
+++ b/jellyfin_kodi/objects/kodi/kodi.py
@@ -158,11 +158,8 @@ class Kodi(object):
             self.cursor.executemany(sql, parameters)
 
     def add_person(self, *args):
-
         self.cursor.execute(QU.add_person, args)
         return self.cursor.lastrowid
-
-        return person_id
 
     def _get_person(self, *args):
         try:

--- a/jellyfin_kodi/objects/kodi/movies.py
+++ b/jellyfin_kodi/objects/kodi/movies.py
@@ -37,16 +37,6 @@ class Movies(Kodi):
 
         return self.cursor.fetchone()[0] + 1
 
-    def create_entry_set(self):
-        self.cursor.execute(QU.create_set)
-
-        return self.cursor.fetchone()[0] + 1
-
-    def create_entry_country(self):
-        self.cursor.execute(QU.create_country)
-
-        return self.cursor.fetchone()[0] + 1
-
     def get(self, *args):
 
         try:
@@ -114,11 +104,8 @@ class Movies(Kodi):
             self.cursor.execute(QU.update_country, (self.get_country(country),) + args)
 
     def add_country(self, *args):
-
-        country_id = self.create_entry_country()
-        self.cursor.execute(QU.add_country, (country_id,) + args)
-
-        return country_id
+        self.cursor.execute(QU.add_country, args)
+        return self.cursor.lastrowid
 
     def get_country(self, *args):
 
@@ -130,11 +117,8 @@ class Movies(Kodi):
             return self.add_country(*args)
 
     def add_boxset(self, *args):
-
-        set_id = self.create_entry_set()
-        self.cursor.execute(QU.add_set, (set_id,) + args)
-
-        return set_id
+        self.cursor.execute(QU.add_set, args)
+        return self.cursor.lastrowid
 
     def update_boxset(self, *args):
         self.cursor.execute(QU.update_set, args)

--- a/jellyfin_kodi/objects/kodi/queries.py
+++ b/jellyfin_kodi/objects/kodi/queries.py
@@ -44,14 +44,6 @@ create_movie = """
 SELECT      coalesce(max(idMovie), 0)
 FROM        movie
 """
-create_set = """
-SELECT      coalesce(max(idSet), 0)
-FROM        sets
-"""
-create_country = """
-SELECT      coalesce(max(country_id), 0)
-FROM        country
-"""
 create_musicvideo = """
 SELECT      coalesce(max(idMVideo), 0)
 FROM        musicvideo
@@ -319,12 +311,12 @@ add_unique_id_movie_obj = ["{Unique}", "{MovieId}", "movie", "{UniqueId}", "{Pro
 add_unique_id_tvshow_obj = ["{Unique}", "{ShowId}", "tvshow", "{UniqueId}", "{ProviderName}"]
 add_unique_id_episode_obj = ["{Unique}", "{EpisodeId}", "episode", "{UniqueId}", "{ProviderName}"]
 add_country = """
-INSERT INTO     country(country_id, name)
-VALUES          (?, ?)
+INSERT INTO     country(name)
+VALUES          (?)
 """
 add_set = """
-INSERT INTO     sets(idSet, strSet, strOverview)
-VALUES          (?, ?, ?)
+INSERT INTO     sets(strSet, strOverview)
+VALUES          (?, ?)
 """
 add_set_obj = ["{Title}", "{Overview}"]
 add_musicvideo = """

--- a/jellyfin_kodi/objects/kodi/queries.py
+++ b/jellyfin_kodi/objects/kodi/queries.py
@@ -12,10 +12,6 @@ create_file = """
 SELECT      coalesce(max(idFile), 0)
 FROM        files
 """
-create_person = """
-SELECT      coalesce(max(actor_id), 0)
-FROM        actor
-"""
 create_genre = """
 SELECT      coalesce(max(genre_id), 0)
 FROM        genre
@@ -225,8 +221,8 @@ VALUES          (?, ?, ?)
 """
 add_file_obj = ["{PathId}", "{Filename}"]
 add_person = """
-INSERT INTO     actor(actor_id, name)
-VALUES          (?, ?)
+INSERT INTO     actor(name)
+VALUES          (?)
 """
 add_people_movie_obj = ["{People}", "{MovieId}", "movie"]
 add_people_mvideo_obj = ["{People}", "{MvideoId}", "musicvideo"]


### PR DESCRIPTION
Hi,

Im opening this PR for input from other devs if that is okay.

Ive tried to reduce the number of calls to sqlite3.execute and sqlite3.fetchone as profiling has highlighted these two as the biggest bottlenecks. I am managing to reduce the number of calls and delete code :) but the profiling is still giving consistent results on the amount of time spent executing each function. Is the effort of continuing with idea worth the effort?

Please see the commit logs for both commits as they contain performance metrics.

Thanks
Damo