### PR TITLE
Finish getitem cleanup in library

### DIFF
--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -675,21 +675,20 @@ class UserDataWorker(threading.Thread):
                 except Queue.Empty:
                     break
 
-                if item['Type'] == 'Movie':
-                    obj = Movies(self.args[0], jellyfindb, kodidb, self.args[1]).userdata(item)
-                elif item['Type'] in ['Series', 'Season', 'Episode']:
-                    obj = TVShows(self.args[0], jellyfindb, kodidb, self.args[1]).userdata(item)
-                elif item['Type'] == 'MusicAlbum':
-                    obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).album
-                elif item['Type'] == 'MusicArtist':
-                    obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).artist
-                elif item['Type'] == 'AlbumArtist':
-                    obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).albumartist
-                elif item['Type'] == 'Audio':
-                    obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).song
 
                 try:
-                    obj(item)
+                    if item['Type'] == 'Movie':
+                        obj = Movies(self.args[0], jellyfindb, kodidb, self.args[1]).userdata(item)
+                    elif item['Type'] in ['Series', 'Season', 'Episode']:
+                        obj = TVShows(self.args[0], jellyfindb, kodidb, self.args[1]).userdata(item)
+                    elif item['Type'] == 'MusicAlbum':
+                        obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).album(item)
+                    elif item['Type'] == 'MusicArtist':
+                        obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).artist(item)
+                    elif item['Type'] == 'AlbumArtist':
+                        obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).albumartist(item)
+                    elif item['Type'] == 'Audio':
+                        obj = Music(self.args[0], jellyfindb, kodidb, self.args[1]).song(item)
                 except LibraryException as error:
                     if error.status == 'StopCalled':
                         break


### PR DESCRIPTION
The `obj(item)` is a relic from when this section was using the getitem dictionary method that I kept missing when working here.  Removing that and making each individual section it's own proper function call for the sake of sanity.  Seems to fix #210 (or at least prevents that error from being thrown)