### PR TITLE
Bad dates are bad

### DIFF
--- a/jellyfin_kodi/helper/utils.py
+++ b/jellyfin_kodi/helper/utils.py
@@ -478,13 +478,13 @@ def convert_to_local(date):
     '''
     try:
         date = parser.parse(date) if isinstance(date, string_types) else date
-        parsed_date = date.replace(tzinfo=tz.tzutc())
-        local_date = parsed_date.astimezone(tz.tzlocal())
+        date = date.replace(tzinfo=tz.tzutc())
+        date = date.astimezone(tz.tzlocal())
         # Bad metadata defaults to date 1-1-1.  Catch it and don't throw errors
-        if local_date.year == 1:
+        if date.year == 1:
             return str(date)
         else:
-            return local_date.strftime('%Y-%m-%dT%H:%M:%S')
+            return date.strftime('%Y-%m-%dT%H:%M:%S')
     except Exception as error:
         LOG.exception('Item date: {} --- {}'.format(str(date), error))
 

--- a/jellyfin_kodi/helper/utils.py
+++ b/jellyfin_kodi/helper/utils.py
@@ -478,12 +478,15 @@ def convert_to_local(date):
     '''
     try:
         date = parser.parse(date) if isinstance(date, string_types) else date
-        date = date.replace(tzinfo=tz.tzutc())
-        date = date.astimezone(tz.tzlocal())
-
-        return date.strftime('%Y-%m-%dT%H:%M:%S')
+        parsed_date = date.replace(tzinfo=tz.tzutc())
+        local_date = parsed_date.astimezone(tz.tzlocal())
+        # Bad metadata defaults to date 1-1-1.  Catch it and don't throw errors
+        if local_date.year == 1:
+            return str(date)
+        else:
+            return local_date.strftime('%Y-%m-%dT%H:%M:%S')
     except Exception as error:
-        LOG.exception(error)
+        LOG.exception('Item date: {} --- {}'.format(str(date), error))
 
         return str(date)
 


### PR DESCRIPTION
When an item from the server doesn't have a proper date, it seems to get set as something along the lines of `'PremiereDate': u'0001-01-01T00:00:00.0000000Z'`, which obviously isn't valid and was throwing errors.  It's harmless, but annoying.  This makes it do a check to see if the year is set to this default value and prevents throwing errors on it.

Also adds the date to the error message in the hopes of tracking down the cause of #153 