### PR TITLE
Updated address normalization to test for https first to fix #223

### DIFF
--- a/jellyfin_kodi/jellyfin/api.py
+++ b/jellyfin_kodi/jellyfin/api.py
@@ -386,7 +386,22 @@ class API(object):
         LOG.debug(request_settings['timeout'])
         LOG.debug(request_settings['headers'])
 
-        return request_method(url, **request_settings)
+        try:
+            return request_method(url, **request_settings)
+        except requests.exceptions.SSLError as e:
+            LOG.error("Failed to connect to server. SSL Issue: %s" % e)
+            response = requests.Response()
+            response.code = "SSL Error: %s".format(e)
+            response.error_type = "SSLError"
+            response.status_code = 500
+            return response
+        except Exception as e:
+            LOG.error("Failed to connect to server. Unhandled Issue: %s" % e)
+            response = requests.Response()
+            response.code = e
+            response.error_type = "UnhandledError"
+            response.status_code = 500
+            return response
 
 
     def login(self, server_url, username, password=""):

--- a/jellyfin_kodi/jellyfin/connection_manager.py
+++ b/jellyfin_kodi/jellyfin/connection_manager.py
@@ -134,6 +134,10 @@ class ConnectionManager(object):
 
         try:
             public_info = self.API.get_public_info(address)
+            if not public_info:
+                LOG.error("connectToAddress %s failed", address)
+                return { 'State': CONNECTION_STATE['Unavailable'] }
+
             LOG.info("connectToAddress %s succeeded", address)
             server = {
                 'address': address,
@@ -286,18 +290,18 @@ class ConnectionManager(object):
         # Attempt to correct bad input
         url = urllib3.util.parse_url(address.strip())
 
-        # Default to using https
+         # Default to using https
         url = url._replace(scheme='https')
-
+      
         # Test if server is reachable over https
         if self.API.get_public_info(url):
-            if url.scheme == 'https' and url.port == 443:
+            if url.port == 443:
                 url = url._replace(port=None)
         else:
             # Server didn't give an expected response over https
             # Try http instead
-            url._replace(scheme='http')
-            if url.scheme == 'http' and url.port == 80:
+            url = url._replace(scheme='http')
+            if url.port == 80:
                 url = url._replace(port=None)
 
         return url.url

--- a/jellyfin_kodi/jellyfin/connection_manager.py
+++ b/jellyfin_kodi/jellyfin/connection_manager.py
@@ -291,6 +291,7 @@ class ConnectionManager(object):
         url = urllib3.util.parse_url(address.strip())
 
          # Default to using https
+        LOG.info("Attempting HTTPS connection")
         url = url._replace(scheme='https')
       
         # Test if server is reachable over https
@@ -300,6 +301,7 @@ class ConnectionManager(object):
         else:
             # Server didn't give an expected response over https
             # Try http instead
+            LOG.info("HTTPS connection failed. Falling back to HTTP")
             url = url._replace(scheme='http')
             if url.port == 80:
                 url = url._replace(port=None)


### PR DESCRIPTION
Resolves #223 where the http->https redirect was causing the server to not respond properly. This changes the default to try HTTPS first, then if that is not available goes down to http