### PR TITLE
Fix ascii error on context menu

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -7,7 +7,7 @@
     <import addon="xbmc.python" version="2.25.0"/>
     <import addon="script.module.requests" version="2.22.0"/>
     <import addon="script.module.dateutil" version="2.7.3"/>
-    <import addon="script.module.six" />
+    <import addon="script.module.six" version="1.13"/>
     <import addon="script.module.kodi-six" />
     <import addon="script.module.addon.signals" version="0.0.1"/>
     <import addon="script.module.futures" version="2.2.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -7,7 +7,7 @@
     <import addon="xbmc.python" version="2.25.0"/>
     <import addon="script.module.requests" version="2.22.0"/>
     <import addon="script.module.dateutil" version="2.7.3"/>
-    <import addon="script.module.six" version="1.13"/>
+    <import addon="script.module.six" version="1.13.0"/>
     <import addon="script.module.kodi-six" />
     <import addon="script.module.addon.signals" version="0.0.1"/>
     <import addon="script.module.futures" version="2.2.0"/>

--- a/jellyfin_kodi/dialogs/context.py
+++ b/jellyfin_kodi/dialogs/context.py
@@ -64,7 +64,7 @@ class ContextMenu(xbmcgui.WindowXMLDialog):
 
             if self.getFocusId() == LIST:
                 option = self.list_.getSelectedItem()
-                self.selected_option = option.getLabel()
+                self.selected_option = option.getLabel().decode('utf-8')
                 LOG.info('option selected: %s', self.selected_option)
 
                 self.close()

--- a/jellyfin_kodi/dialogs/context.py
+++ b/jellyfin_kodi/dialogs/context.py
@@ -7,6 +7,7 @@ import logging
 import os
 
 from kodi_six import xbmcgui, xbmcaddon
+from six import ensure_text
 
 from helper import window, addon_id
 
@@ -64,7 +65,7 @@ class ContextMenu(xbmcgui.WindowXMLDialog):
 
             if self.getFocusId() == LIST:
                 option = self.list_.getSelectedItem()
-                self.selected_option = option.getLabel().decode('utf-8')
+                self.selected_option = ensure_text(option.getLabel())
                 LOG.info('option selected: %s', self.selected_option)
 
                 self.close()


### PR DESCRIPTION
Fixes the ascii decoding error when selecting an option with special characters in the context menu of an item.  It seems as though Kodi's internal getLabel return true strings and not respecting the `unicode_literals` in this file

Fixes #220 (again)