### PR TITLE
Fix capitalization in boxsets

### DIFF
--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -618,7 +618,7 @@ class UpdateWorker(threading.Thread):
                 default_args = (self.server, jellyfindb, kodidb, self.direct_path)
                 if item['Type'] == 'Movie':
                     obj = Movies(*default_args).movie
-                elif item['Type'] == 'Boxset':
+                elif item['Type'] == 'BoxSet':
                     obj = Movies(*default_args).boxset
                 elif item['Type'] == 'Series':
                     obj = TVShows(*default_args).tvshow


### PR DESCRIPTION
Typo here was causing collections to not sync properly.  Possibly related to #218, but more testing is needed