### PR TITLE
Follow redirects when connecting to server

### DIFF
--- a/jellyfin_kodi/jellyfin/api.py
+++ b/jellyfin_kodi/jellyfin/api.py
@@ -412,7 +412,7 @@ class API(object):
 
                 return {}
         except Exception as e: # Find exceptions for likely cases i.e, server timeout, etc
-            LOG.error(e) 
+            LOG.error(e)
 
         return {}
 
@@ -431,3 +431,12 @@ class API(object):
     def get_public_info(self, server_address):
         response = self.send_request(server_address, "system/info/public")
         return response.json() if response.status_code == 200 else {}
+
+    def check_redirect(self, server_address):
+        ''' Checks if the server is redirecting traffic to a new URL and
+        returns the URL the server prefers to use
+        '''
+        response = self.send_request(server_address, "system/info/public")
+        url = response.url.replace('/system/info/public', '')
+        return url
+


### PR DESCRIPTION
When a proxy has a 301/302 redirect in front of JF this will follow them and update the stored URL.  This solves the problem where authentication headers don't follow a redirect and reduces load on the reverse proxy by going to the proper endpoint instead of requiring all requests to get redirected.  Alternative solution to #233 
Fixes #223 

Sorry for ugly diff, my editor automatically removes extra whitespace (of which there was apparently a good amount here)