### PR TITLE
Remove duplicate strings in translations

### DIFF
--- a/jellyfin_kodi/entrypoint/default.py
+++ b/jellyfin_kodi/entrypoint/default.py
@@ -180,7 +180,7 @@ def listing():
     directory(translate(33054), "plugin://plugin.video.jellyfin/?mode=adduser", False)
     directory(translate(5), "plugin://plugin.video.jellyfin/?mode=settings", False)
     directory(translate(33058), "plugin://plugin.video.jellyfin/?mode=reset", False)
-    directory(translate(33192), "plugin://plugin.video.jellyfin/?mode=restartservice", False)
+    directory(translate(33180), "plugin://plugin.video.jellyfin/?mode=restartservice", False)
 
     if settings('backupPath'):
         directory(translate(33092), "plugin://plugin.video.jellyfin/?mode=backup", False)

--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -736,7 +736,7 @@ msgctxt "#33181"
 msgid "Restarting to apply the patch"
 msgstr "Restart pro aplikování opravy"
 
-msgctxt "#33192"
+msgctxt "#33180"
 msgid "Restart Jellyfin for Kodi"
 msgstr "Restartovat Jellyfin pro Kodi"
 

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -945,7 +945,7 @@ msgstr "Transkodierung erzwingen"
 
 msgctxt "#33180"
 msgid "Restart Jellyfin for Kodi"
-msgstr "'Jellyfin for Kodi' neustarten"
+msgstr "Jellyfin für Kodi neustarten"
 
 msgctxt "#33181"
 msgid "Restarting to apply the patch"
@@ -992,10 +992,6 @@ msgstr "'Kodi Datenbankerkennung' aktivieren?"
 msgctxt "#33191"
 msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr "Jellyfin für Kodi Neustarten zum Anwenden der Änderung?"
-
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr "Jellyfin für Kodi neustarten"
 
 msgctxt "#33193"
 msgid "Restarting..."

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -908,10 +908,6 @@ msgctxt "#33191"
 msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr "Restart Jellyfin for Kodi to apply this change?"
 
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr "Restart Jellyfin for Kodi"
-
 msgctxt "#33193"
 msgid "Restarting..."
 msgstr "Restarting..."

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -908,10 +908,6 @@ msgctxt "#33191"
 msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr "Restart Jellyfin for Kodi to apply this change?"
 
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr "Restart Jellyfin for Kodi"
-
 msgctxt "#33193"
 msgid "Restarting..."
 msgstr "Restarting..."

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -928,10 +928,6 @@ msgctxt "#33191"
 msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr "¿Reiniciar Jellyfin para Kodi para aplicar este cambio?"
 
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr "Reiniciar Jellyfin para Kodi"
-
 msgctxt "#33193"
 msgid "Restarting..."
 msgstr "Reiniciando…"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -985,10 +985,6 @@ msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr ""
 "Voulez-vous redémarrer Jellyfin pour Kodi pour appliquer ce changement ?"
 
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr "Redémarrer Jellyfin pour Kodi"
-
 msgctxt "#33193"
 msgid "Restarting..."
 msgstr "Redémarrage..."

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -540,7 +540,7 @@ msgctxt "#33181"
 msgid "Restarting to apply the patch"
 msgstr "Újraindítás folyamatban a javítások alkalmazásához"
 
-msgctxt "#33192"
+msgctxt "#33180"
 msgid "Restart Jellyfin for Kodi"
 msgstr "Jellyfin Kodi bővítmény újraindítása"
 

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -984,10 +984,6 @@ msgctxt "#33191"
 msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr "Riavvia Jellyfin per Kodi per applicare questo cambiamento?"
 
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr "Riavvia Jellyfin per Kodi"
-
 msgctxt "#33193"
 msgid "Restarting..."
 msgstr "Riavvio..."

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -873,10 +873,6 @@ msgctxt "#33191"
 msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr ""
 
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr ""
-
 msgctxt "#33193"
 msgid "Restarting..."
 msgstr ""

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -876,10 +876,6 @@ msgctxt "#33191"
 msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr "변경사항을 적용하기위해 Jellyfin for Kodi를 재시작하시겠습니까?"
 
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr "Jellyfin for Kodi 재시작"
-
 msgctxt "#33193"
 msgid "Restarting..."
 msgstr "재시작 중..."

--- a/resources/language/resource.language.lv_lv/strings.po
+++ b/resources/language/resource.language.lv_lv/strings.po
@@ -360,7 +360,7 @@ msgctxt "#33181"
 msgid "Restarting to apply the patch"
 msgstr "Restartē lai uzstādītu ielāpu"
 
-msgctxt "#33192"
+msgctxt "#33180"
 msgid "Restart Jellyfin for Kodi"
 msgstr "Restartēt Jellyfin priekš Kodi"
 

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -918,10 +918,6 @@ msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr ""
 "Start Jellyfin for Kodi på nytt for at denne endringen skal tre i kraft?"
 
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr "Start Jellyfin for Kodi på nytt"
-
 msgctxt "#33193"
 msgid "Restarting..."
 msgstr "Starter på nytt..."

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -971,10 +971,6 @@ msgctxt "#33191"
 msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr "Jellyfin for Kodi opnieuw opstarten om de wijziging toe te passen?"
 
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr "Jellyfin for Kodi opnieuw starten"
-
 msgctxt "#33193"
 msgid "Restarting..."
 msgstr "Opnieuw opstarten..."

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -961,10 +961,6 @@ msgctxt "#33191"
 msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr "Zrestartować Jellyfin dla Kodi by zaaplikować tę zmianę?"
 
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr "Zrestartuj Jellyfin dla Kodi"
-
 msgctxt "#33193"
 msgid "Restarting..."
 msgstr "Restartowanie..."

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -891,7 +891,7 @@ msgstr "Forçar transcodificação"
 
 msgctxt "#33180"
 msgid "Restart Jellyfin for Kodi"
-msgstr ""
+msgstr "Reiniciar Jellyfin for Kodi"
 
 msgctxt "#33181"
 msgid "Restarting to apply the patch"
@@ -923,10 +923,6 @@ msgstr ""
 msgctxt "#33191"
 msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr "Reinciar Jellyfin for Kodi para aplicar essa mudança?"
-
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr "Reiniciar Jellyfin for Kodi"
 
 msgctxt "#33193"
 msgid "Restarting..."

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -865,10 +865,6 @@ msgctxt "#33191"
 msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr ""
 
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr ""
-
 msgctxt "#33193"
 msgid "Restarting..."
 msgstr ""

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -901,10 +901,6 @@ msgctxt "#33191"
 msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr "Перезапустить Jellyfin для Kodi, чтобы применить это изменение?"
 
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr "Перезапустить Jellyfin для Kodi"
-
 msgctxt "#33193"
 msgid "Restarting..."
 msgstr "Перезапускается…"

--- a/resources/language/resource.language.sk_sk/strings.po
+++ b/resources/language/resource.language.sk_sk/strings.po
@@ -889,7 +889,7 @@ msgstr "Vynútiť transkódovanie"
 
 msgctxt "#33180"
 msgid "Restart Jellyfin for Kodi"
-msgstr ""
+msgstr "Reštartovať Jellyfin for Kodi"
 
 msgctxt "#33181"
 msgid "Restarting to apply the patch"
@@ -920,10 +920,6 @@ msgstr ""
 msgctxt "#33191"
 msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr "Reštartovať Jellyfin pre Kodi pre aplikovanie zmien?"
-
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr "Reštartovať Jellyfin for Kodi"
 
 msgctxt "#33193"
 msgid "Restarting..."

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -837,7 +837,7 @@ msgstr "强制转码"
 
 msgctxt "#33180"
 msgid "Restart Jellyfin for Kodi"
-msgstr "重启Jellyfin for Kodi"
+msgstr "重启Jellyfin的Kodi组件"
 
 msgctxt "#33181"
 msgid "Restarting to apply the patch"
@@ -866,10 +866,6 @@ msgstr "Kodi伴侣将加速启动时的同步。其他的同步将由服务器�
 msgctxt "#33191"
 msgid "Restart Jellyfin for Kodi to apply this change?"
 msgstr "重启Jellyfin for Kodi以应用更改？"
-
-msgctxt "#33192"
-msgid "Restart Jellyfin for Kodi"
-msgstr "重启Jellyfin的Kodi组件"
 
 msgctxt "#33193"
 msgid "Restarting..."


### PR DESCRIPTION
Weblate was throwing alerts for duplicate strings on 'Restart Jellyfin for Kodi', so this consolidates them into a single entry