### PR TITLE
Don't encode strings that don't need it

### DIFF
--- a/jellyfin_kodi/jellyfin/api.py
+++ b/jellyfin_kodi/jellyfin/api.py
@@ -355,10 +355,10 @@ class API(object):
 
     def get_default_headers(self):
         auth = "MediaBrowser "
-        auth += "Client=%s, " % self.config.data['app.name'].encode('utf-8')
-        auth += "Device=%s, " % self.config.data['app.device_name'].encode('utf-8')
-        auth += "DeviceId=%s, " % self.config.data['app.device_id'].encode('utf-8')
-        auth += "Version=%s" % self.config.data['app.version'].encode('utf-8')
+        auth += "Client=%s, " % self.config.data['app.name']
+        auth += "Device=%s, " % self.config.data['app.device_name']
+        auth += "DeviceId=%s, " % self.config.data['app.device_id']
+        auth += "Version=%s" % self.config.data['app.version']
 
         return {
             "Accept": "application/json",


### PR DESCRIPTION
Copied from https://github.com/iwalton3/jellyfin-apiclient-python/commit/24c9e6c16aa594eacad9fc97cf3f29c27f306d62, tested and verified on Kodi 18.6.  These strings don't need to be encoded to work properly.