### PR TITLE
Disabled changing server details & Removed corresponding function

### DIFF
--- a/jellyfin_kodi/entrypoint/default.py
+++ b/jellyfin_kodi/entrypoint/default.py
@@ -105,8 +105,6 @@ class Events(object):
             xbmc.executebuiltin('Addon.OpenSettings(plugin.video.jellyfin)')
         elif mode == 'adduser':
             add_user()
-        elif mode == 'updateserver':
-            event('UpdateServer')
         elif mode == 'thememedia':
             get_themes()
         elif mode == 'managelibs':

--- a/jellyfin_kodi/entrypoint/service.py
+++ b/jellyfin_kodi/entrypoint/service.py
@@ -161,7 +161,7 @@ class Service(xbmc.Monitor):
             if method not in ('ServerUnreachable', 'ServerShuttingDown', 'UserDataChanged', 'ServerConnect',
                               'LibraryChanged', 'ServerOnline', 'SyncLibrary', 'RepairLibrary', 'RemoveLibrary',
                               'SyncLibrarySelection', 'RepairLibrarySelection', 'AddServer',
-                              'Unauthorized', 'UpdateServer', 'UserConfigurationUpdated', 'ServerRestarting',
+                              'Unauthorized', 'UserConfigurationUpdated', 'ServerRestarting',
                               'RemoveServer', 'AddLibrarySelection', 'RemoveLibrarySelection'):
                 return
 
@@ -248,11 +248,6 @@ class Service(xbmc.Monitor):
 
             self.connect.remove_server(data['Id'])
             xbmc.executebuiltin("Container.Refresh")
-
-        elif method == 'UpdateServer':
-
-            dialog("ok", heading="{jellyfin}", line1=translate(33151))
-            self.connect.setup_manual_server()
 
         elif method == 'UserDataChanged' and self.library_thread:
             if data.get('ServerId') or not window('jellyfin_startup.bool'):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -2,11 +2,10 @@
 <settings>
 
 	<category label="29999"><!-- Jellyfin -->
-		<setting label="30003" id="idMethod" type="enum" values="Manual" default="0" />
-		<setting label="30024" id="username" type="text" default="" visible="true" />
-		<setting label="30001" id="serverName" type="text" default="" />
-		<setting label="30000" id="server" type="text" default="" visible="true" />
-		<setting label="33150" type="action" action="RunPlugin(plugin://plugin.video.jellyfin?mode=updateserver)" visible="!eq(-1,)" option="close" />
+		<setting label="30003" id="idMethod" type="enum" values="Manual" default="0" enable="false" />
+		<setting label="30024" id="username" type="text" default="" visible="true" enable="false" />
+		<setting label="30001" id="serverName" type="text" default="" enable="false" />
+		<setting label="30000" id="server" type="text" default="" visible="true" enable="false" />
 		<setting label="30500" id="sslverify" type="bool" default="true" visible="true" />
 
 		<setting type="sep" />


### PR DESCRIPTION
resolves #250 where a user could change the server in the settings but that didn't update the library paths so a reset is required when changing server to get the new server path reflected in the library paths