### PR TITLE
Fix library errors before login occurs

### DIFF
--- a/jellyfin_kodi/entrypoint/service.py
+++ b/jellyfin_kodi/entrypoint/service.py
@@ -69,11 +69,6 @@ class Service(xbmc.Monitor):
 
         verify_kodi_defaults()
 
-        try:
-            Views().get_nodes()
-        except Exception as error:
-            LOG.exception(error)
-
         window('jellyfin.connected.bool', True)
         settings('groupedSets.bool', objects.utils.get_grouped_set())
         xbmc.Monitor.__init__(self)


### PR DESCRIPTION
Fixes some of the annoying startup errors:
```
2020-05-15 01:07:05.362 T:140312934532864  NOTICE: JELLYFIN.jellyfin.http -> ERROR::jellyfin_kodi/jellyfin/http.py:154 Request missing Schema. Invalid URL '/Users/{UserId}/Items': No schema supplied. Perhaps you meant http:///Users/{UserId}/Items?
2020-05-15 01:07:05.363 T:140312934532864  NOTICE: JELLYFIN.views -> ERROR::jellyfin_kodi/views.py:177
                                            Traceback (most recent call last):
                                              File "jellyfin_kodi/views.py", line 174, in get_libraries
                                                libraries = self.server.jellyfin.get_media_folders()['Items']
                                              File "jellyfin_kodi/jellyfin/api.py", line 135, in get_media_folders
                                                return self.users("/Items")
                                              File "jellyfin_kodi/jellyfin/api.py", line 91, in users
                                                return self._get("Users/{UserId}%s" % handler, params)
                                              File "jellyfin_kodi/jellyfin/api.py", line 60, in _get
                                                return self._http("GET", handler, {'params': params})
                                              File "jellyfin_kodi/jellyfin/api.py", line 57, in _http
                                                return self.client.request(request)
                                              File "jellyfin_kodi/jellyfin/http.py", line 155, in request
                                                raise HTTPException("MissingSchema", {'Id': self.config.data.get('auth.server', "None")})
                                            HTTPException
2020-05-15 01:07:05.364 T:140312934532864  NOTICE: JELLYFIN.views -> ERROR::jellyfin_kodi/views.py:735 Unable to retrieve libraries:
                                            Traceback (most recent call last):
                                              File "jellyfin_kodi/views.py", line 733, in window_nodes
                                                self.media_folders = self.get_libraries()
                                              File "jellyfin_kodi/views.py", line 178, in get_libraries
                                                raise IndexError("Unable to retrieve libraries: %s" % error)
                                            IndexError: Unable to retrieve libraries:
```

The original commit message for this piece of code was https://github.com/jellyfin/jellyfin-kodi/commit/313585efff66a4ca436ab8fad137771931a974bd, but as far as I can tell it's not causing any errors without this in place.  Possibly the root cause was fixed in one of our other PRs improving the xml handling.