### PR TITLE
Improve addon menu

### DIFF
--- a/jellyfin_kodi/entrypoint/default.py
+++ b/jellyfin_kodi/entrypoint/default.py
@@ -160,14 +160,7 @@ def listing():
         LOG.debug("--[ listing/%s/%s ] %s", node, label, path)
 
         if path:
-            if xbmc.getCondVisibility('Window.IsActive(Pictures)') and node in ('photos', 'homevideos'):
-                directory(label, path, artwork=artwork)
-            elif xbmc.getCondVisibility('Window.IsActive(Videos)') and node not in ('photos', 'music', 'audiobooks'):
-                directory(label, path, artwork=artwork, context=context)
-            elif xbmc.getCondVisibility('Window.IsActive(Music)') and node in ('music'):
-                directory(label, path, artwork=artwork, context=context)
-            elif not xbmc.getCondVisibility('Window.IsActive(Videos) | Window.IsActive(Pictures) | Window.IsActive(Music)'):
-                directory(label, path, artwork=artwork)
+            directory(label, path, artwork=artwork, context=context)
 
     for server in servers:
         context = []

--- a/jellyfin_kodi/views.py
+++ b/jellyfin_kodi/views.py
@@ -166,13 +166,10 @@ class Views(object):
     def get_libraries(self):
 
         try:
-            libraries = self.server.jellyfin.get_media_folders()['Items']
-            views = self.server.jellyfin.get_views()['Items']
+            libraries = self.server.jellyfin.get_views()['Items']
         except Exception as error:
             LOG.exception(error)
             raise IndexError("Unable to retrieve libraries: %s" % error)
-
-        libraries.extend([x for x in views if x['Id'] not in [y['Id'] for y in libraries]])
 
         return libraries
 


### PR DESCRIPTION
Adds `Music` as an option when browsing through the addon menu, as well as gets rid of redundant `Playlists` entry.  Fixes #295 

Before Changes:
![before](https://user-images.githubusercontent.com/17029228/82103488-2ae9e100-96e1-11ea-9cbe-3f7d7f7777d3.png)

After Changes:
![after](https://user-images.githubusercontent.com/17029228/82103492-2cb3a480-96e1-11ea-8ca9-484a2d1a70d7.png)
