### PR TITLE
Add reset password dialog to addon menu

### DIFF
--- a/jellyfin_kodi/connect.py
+++ b/jellyfin_kodi/connect.py
@@ -119,6 +119,10 @@ class Connect(object):
                 if 'ExchangeToken' not in state['Servers'][0]:
                     self.login()
 
+            elif state['State'] == CONNECTION_STATE['Unavailable'] and state['Status_Code'] == 401:
+                # If the saved credentials don't work, restart the addon to force the password dialog to open
+                window('jellyfin.restart', clear=True)
+
             elif state['State'] == CONNECTION_STATE['Unavailable']:
                 raise HTTPException('ServerUnreachable', {})
 

--- a/jellyfin_kodi/connect.py
+++ b/jellyfin_kodi/connect.py
@@ -253,8 +253,9 @@ class Connect(object):
         client.set_credentials(get_credentials())
         manager = client.auth
 
+        username = settings('username')
         try:
-            self.login_manual(manager=manager)
+            self.login_manual(user=username, manager=manager)
         except RuntimeError:
             return
 

--- a/jellyfin_kodi/entrypoint/default.py
+++ b/jellyfin_kodi/entrypoint/default.py
@@ -112,6 +112,8 @@ class Events(object):
             xbmc.executebuiltin('Addon.OpenSettings(plugin.video.jellyfin)')
         elif mode == 'adduser':
             add_user()
+        elif mode == 'updatepassword':
+            event('UpdatePassword')
         elif mode == 'thememedia':
             get_themes()
         elif mode == 'managelibs':
@@ -177,6 +179,7 @@ def listing():
     directory(translate(33134), "plugin://plugin.video.jellyfin/?mode=addserver", False)
     directory(translate(33054), "plugin://plugin.video.jellyfin/?mode=adduser", False)
     directory(translate(5), "plugin://plugin.video.jellyfin/?mode=settings", False)
+    directory(translate(33161), "plugin://plugin.video.jellyfin/?mode=updatepassword", False)
     directory(translate(33058), "plugin://plugin.video.jellyfin/?mode=reset", False)
     directory(translate(33180), "plugin://plugin.video.jellyfin/?mode=restartservice", False)
 

--- a/jellyfin_kodi/entrypoint/service.py
+++ b/jellyfin_kodi/entrypoint/service.py
@@ -156,7 +156,7 @@ class Service(xbmc.Monitor):
                               'LibraryChanged', 'ServerOnline', 'SyncLibrary', 'RepairLibrary', 'RemoveLibrary',
                               'SyncLibrarySelection', 'RepairLibrarySelection', 'AddServer',
                               'Unauthorized', 'UserConfigurationUpdated', 'ServerRestarting',
-                              'RemoveServer', 'AddLibrarySelection', 'RemoveLibrarySelection'):
+                              'RemoveServer', 'UpdatePassword', 'AddLibrarySelection', 'RemoveLibrarySelection'):
                 return
 
             data = json.loads(data)[0]
@@ -243,6 +243,8 @@ class Service(xbmc.Monitor):
             self.connect.remove_server(data['Id'])
             xbmc.executebuiltin("Container.Refresh")
 
+        elif method == 'UpdatePassword':
+            self.connect.setup_login_manual()
         elif method == 'UserDataChanged' and self.library_thread:
             if data.get('ServerId') or not window('jellyfin_startup.bool'):
                 return

--- a/jellyfin_kodi/jellyfin/api.py
+++ b/jellyfin_kodi/jellyfin/api.py
@@ -434,7 +434,7 @@ class API(object):
         if response.status_code == 200:
             return response.json()
         else:
-            return response.status_code
+            return { 'Status_Code': response.status_code }
 
     def get_public_info(self, server_address):
         response = self.send_request(server_address, "system/info/public")

--- a/jellyfin_kodi/jellyfin/api.py
+++ b/jellyfin_kodi/jellyfin/api.py
@@ -430,7 +430,11 @@ class API(object):
         headers.update(auth_token_header)
 
         response = self.send_request(server['address'], "system/info", headers=headers)
-        return response.json() if response.status_code == 200 else {}
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            return response.status_code
 
     def get_public_info(self, server_address):
         response = self.send_request(server_address, "system/info/public")

--- a/jellyfin_kodi/jellyfin/connection_manager.py
+++ b/jellyfin_kodi/jellyfin/connection_manager.py
@@ -309,7 +309,7 @@ class ConnectionManager(object):
 
         elif verify_authentication and server.get('AccessToken'):
             system_info = self.API.validate_authentication_token(server)
-            if system_info:
+            if system_info and type(system_info) == dict:
 
                 self._update_server_info(server, system_info)
                 self.config.data['auth.user_id'] = server['UserId']
@@ -319,7 +319,9 @@ class ConnectionManager(object):
 
             server['UserId'] = None
             server['AccessToken'] = None
-            return {'State': CONNECTION_STATE['Unavailable']}
+            return {
+                'State': CONNECTION_STATE['Unavailable'],
+                'Status_Code': system_info}
 
         self._update_server_info(server, system_info)
 

--- a/jellyfin_kodi/jellyfin/connection_manager.py
+++ b/jellyfin_kodi/jellyfin/connection_manager.py
@@ -309,7 +309,7 @@ class ConnectionManager(object):
 
         elif verify_authentication and server.get('AccessToken'):
             system_info = self.API.validate_authentication_token(server)
-            if system_info and type(system_info) == dict:
+            if 'Status_Code' not in system_info:
 
                 self._update_server_info(server, system_info)
                 self.config.data['auth.user_id'] = server['UserId']
@@ -319,9 +319,8 @@ class ConnectionManager(object):
 
             server['UserId'] = None
             server['AccessToken'] = None
-            return {
-                'State': CONNECTION_STATE['Unavailable'],
-                'Status_Code': system_info}
+            system_info['State'] = CONNECTION_STATE['Unavailable']
+            return system_info
 
         self._update_server_info(server, system_info)
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -801,6 +801,10 @@ msgctxt "#33160"
 msgid "To avoid errors, please update Jellyfin for Kodi to version: "
 msgstr "To avoid errors, please update Jellyfin for Kodi to version: "
 
+msgctxt "#33161"
+msgid "Update password"
+msgstr "Update password"
+
 msgctxt "#33162"
 msgid "Reset the music library?"
 msgstr "Reset the music library?"

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -801,6 +801,10 @@ msgctxt "#33160"
 msgid "To avoid errors, please update Jellyfin for Kodi to version: "
 msgstr "To avoid errors, please update Jellyfin for Kodi to version: "
 
+msgctxt "#33161"
+msgid "Update password"
+msgstr "Update password"
+
 msgctxt "#33162"
 msgid "Reset the music library?"
 msgstr "Reset the music library?"


### PR DESCRIPTION
This dialog only works if Kodi was running when the password was reset in the Web UI.  ~~If Kodi is turned off when the password is reset, then it will automatically let you reset it by starting/stopping/starting Kodi again.  I wanted to catch that so it doesn't need the extra restart cycle, but it's pretty deep and there's not a super good way to verify it's a bad password vs the server just being offline that I can see right now.~~

Fixes #258

Edit: fixed in later commit