### PR TITLE
Fix server selection list to show multiple servers

### DIFF
--- a/jellyfin_kodi/connect.py
+++ b/jellyfin_kodi/connect.py
@@ -159,12 +159,13 @@ class Connect(object):
         user = {}
 
         dialog = ServerConnect("script-jellyfin-connect-server.xml", *XML_PATH)
-        dialog.set_args(**{
-            'connect_manager': self.connect_manager,
-            'username': user.get('DisplayName', ""),
-            'user_image': user.get('ImageUrl'),
-            'servers': state.get('Servers', [])
-        })
+        dialog.set_args(
+            connect_manager=self.connect_manager,
+            username=user.get('DisplayName', ""),
+            user_image=user.get('ImageUrl'),
+            servers=self.connect_manager.get_available_servers()
+        )
+
         dialog.doModal()
 
         if dialog.is_server_selected():

--- a/jellyfin_kodi/jellyfin/credentials.py
+++ b/jellyfin_kodi/jellyfin/credentials.py
@@ -76,7 +76,7 @@ class Credentials(object):
             raise KeyError("Server['Id'] cannot be null or empty")
 
         # Add default DateLastAccessed if doesn't exist.
-        server.setdefault('DateLastAccessed', "2001-01-01T00:00:00Z")
+        server.setdefault('DateLastAccessed', "1970-01-01T00:00:00Z")
 
         for existing in servers:
             if existing['Id'] == server['Id']:


### PR DESCRIPTION
Now displays all servers instead of just the "first" one, including manually added servers.