### PR TITLE
Fix choose the audio stream and the subtitle stream remotely

### DIFF
--- a/jellyfin_kodi/monitor.py
+++ b/jellyfin_kodi/monitor.py
@@ -389,6 +389,8 @@ class Monitor(xbmc.Monitor):
             elif command == 'SetSubtitleStreamIndex':
                 self.player.set_audio_subs(None, args['Index'])
 
+            # Kodi needs a bit of time to update it's current status
+            xbmc.sleep(500)
             self.player.report_playback()
 
         elif command == 'DisplayMessage':

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -155,6 +155,10 @@ class Player(xbmc.Player):
         LOG.info("-->[ play/%s ] %s", item['Id'], item)
 
     def set_audio_subs(self, audio=None, subtitle=None):
+        if audio:
+            audio=int(audio)
+        if subtitle:
+            subtitle=int(subtitle)
 
         ''' Only for after playback started
         '''
@@ -169,7 +173,7 @@ class Player(xbmc.Player):
             if audio and len(self.getAvailableAudioStreams()) > 1:
                 self.setAudioStream(audio - 1)
 
-            if subtitle == -1 or subtitle is None:
+            if subtitle is None or subtitle == -1:
                 self.showSubtitles(False)
 
                 return


### PR DESCRIPTION
Partially solves the problem #309 
However the poster in the remote interface does not update the first time when I activate or deactivate the subtitles. And the modifications in Koni do not go up in the remote interface.
If I trigger an event on the player like putting it on pause, the information is updated. For what is modifications in Kodi and for activation / deactivation in the remote interface.

I have not done any tests on other versions of Kodi and Jellyfin, so I don't know if my changes are compatible with other versions.

