### PR TITLE
Fix incremental sync for mixed content libraries

### DIFF
--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -375,10 +375,11 @@ class Library(threading.Thread):
         include = []
         filters = ["tvshows", "boxsets", "musicvideos", "music", "movies"]
         sync = get_sync()
+        whitelist = [ x.replace('Mixed:', "") for x in sync['Whitelist'] ]
         LOG.info("--[ retrieve changes ] %s", last_sync)
 
         # Get the item type of each synced library and build list of types to request
-        for item_id in sync['Whitelist']:
+        for item_id in whitelist:
             library = self.server.jellyfin.get_item(item_id)
             library_type = library.get('CollectionType')
             if library_type in filters:


### PR DESCRIPTION
The list of library IDs in the stored sync file looks like this:
```
"Whitelist": [
    "e2c00f297a5f80af390f52f72e782147",
    "767bffe4f11c93ef34b805451a696a4e",
    "Mixed:122ca211c46006b344d85950f9ed4368",
    "f137a2dd21bbc1b99aa5c0f6bf02a805",
    "7e64e319657a9516ec78490da03edccb"
]
```
This obviously throws errors when a mixed content library is present and prevents the incremental sync from running on startup.

We could technically find where it's being written and make them all normal item IDs instead of having this one be weird, but given how mixed content libraries are the red headed step child and have some weird behavior everywhere else anyway, I think I like the idea of making sure it stands out.