### PR TITLE
Force filter parameter during incremental sync

### DIFF
--- a/jellyfin_kodi/jellyfin/api.py
+++ b/jellyfin_kodi/jellyfin/api.py
@@ -329,7 +329,7 @@ class API(object):
     def get_sync_queue(self, date, filters=None):
         return self._get("Jellyfin.Plugin.KodiSyncQueue/{UserId}/GetItems", params={
             'LastUpdateDT': date,
-            'filter': filters or None
+            'filter': filters or 'None'
         })
 
     def get_server_time(self):


### PR DESCRIPTION
Some servers seem to return an error if the url doesn't have a `filter` parameter when checking Kodi Sync Queue, but I can't replicate it on mine right now.  Only comes into play when users have libraries of each media type synced (Movie, TV Show, Music, Music Video)

Ref: https://forum.jellyfin.org/t/jellyfin-for-kodi-0-5-6-breaks-kodisyncqueue/2221/17