### PR TITLE
Add support for BDMV movie directories in native playback mode

### DIFF
--- a/jellyfin_kodi/helper/__init__.py
+++ b/jellyfin_kodi/helper/__init__.py
@@ -13,6 +13,7 @@ from .utils import dialog
 from .utils import find
 from .utils import event
 from .utils import validate
+from .utils import validate_bluray_dir
 from .utils import values
 from .utils import JSONRPC
 from .utils import compare_version

--- a/jellyfin_kodi/helper/utils.py
+++ b/jellyfin_kodi/helper/utils.py
@@ -268,8 +268,6 @@ def validate_bluray_dir(path):
 
     path = path + '/BDMV/'
 
-    path = path if os.path.supports_unicode_filenames else path
-
     if not xbmcvfs.exists(path):
         return False
 

--- a/jellyfin_kodi/helper/utils.py
+++ b/jellyfin_kodi/helper/utils.py
@@ -261,6 +261,23 @@ def validate(path):
     return True
 
 
+def validate_bluray_dir(path):
+
+    ''' Verify if path/BDMV/ is accessible.
+    '''
+
+    path = path + '/BDMV/'
+
+    path = path if os.path.supports_unicode_filenames else path
+
+    if not xbmcvfs.exists(path):
+        return False
+
+    window('jellyfin_pathverified.bool', True)
+
+    return True
+
+
 def values(item, keys):
 
     ''' Grab the values in the item for a list of keys {key},{key1}....

--- a/jellyfin_kodi/objects/movies.py
+++ b/jellyfin_kodi/objects/movies.py
@@ -180,7 +180,7 @@ class Movies(KodiDb):
             if validate_bluray_dir(obj['Path'] + obj['Filename']):
                 obj['Path'] = obj['Path'] + obj['Filename'] + '/BDMV/'
                 obj['Filename'] = 'index.bdmv'
-                LOG.debug("path redirect %s",obj['Path'])
+                LOG.debug("Bluray directry %s",obj['Path'])
 
         else:
             obj['Path'] = "plugin://plugin.video.jellyfin/%s/" % obj['LibraryId']

--- a/jellyfin_kodi/objects/movies.py
+++ b/jellyfin_kodi/objects/movies.py
@@ -8,7 +8,7 @@ from kodi_six.utils import py2_encode
 
 import downloader as server
 from database import jellyfin_db, queries as QUEM
-from helper import api, stop, validate, jellyfin_item, library_check, values, Local
+from helper import api, stop, validate, validate_bluray_dir, jellyfin_item, library_check, values, Local
 from helper import LazyLogger
 
 from .obj import Objects
@@ -176,6 +176,11 @@ class Movies(KodiDb):
                 raise Exception("Failed to validate path. User stopped.")
 
             obj['Path'] = obj['Path'].replace(obj['Filename'], "")
+            '''check bluray directries and point it to ./BDMV/index.bdmv'''
+            if validate_bluray_dir(obj['Path'] + obj['Filename']):
+                obj['Path'] = obj['Path'] + obj['Filename'] + '/BDMV/'
+                obj['Filename'] = 'index.bdmv'
+                LOG.debug("path redirect %s",obj['Path'])
 
         else:
             obj['Path'] = "plugin://plugin.video.jellyfin/%s/" % obj['LibraryId']


### PR DESCRIPTION
Add support for BDMV movies in the bluray directry by pointing the file to **./BDMV/index.bdmv** when using **direct path**
related issue #33 

Originally, kodi can't play the movie synced by jellyfin for kodi with **Playback mode: Native (direct paths)** if the bdmv is in a directry like this:
Casino.Royale.2006.COMPLETE.UHD.BLURAY-COASTER/
.
└── Casino.Royale.2006.COMPLETE.UHD.BLURAY-COASTER
    ├── BDMV
    │   ├── BACKUP
    │   ├── BDJO
    │   ├── CLIPINF
    │   ├── JAR
    │   ├── META
    │   ├── PLAYLIST
    │   ├── STREAM
    │   ├── index.bdmv
    │   └── MovieObject.bdmv
    ├── CERTIFICATE
    │   ├── BACKUP
    │   ├── app.discroot.crt
    │   ├── bu.discroot.crt
    │   └── id.bdmv
    ├── Casino.Royale.2006.COMPLETE.UHD.BLURAY-COASTER.nfo
    ├── fanart.jpg
    ├── landscape.jpg
    ├── logo.png
    └── poster.jpg

Jellyfin server tells jellyfin for kodi only the directry of the bdmv, in this case, **Casino.Royale.2006.COMPLETE.UHD.BLURAY-COASTER**, but kodi needs the 'BDMV/index.bdmv' file, which, in this case, should be **Casino.Royale.2006.COMPLETE.UHD.BLURAY-COASTER/BDMV/index.bdmv**. So just give kodi what it wants.