### PR TITLE
Don't process songs from unsynced libraries

### DIFF
--- a/jellyfin_kodi/objects/music.py
+++ b/jellyfin_kodi/objects/music.py
@@ -209,6 +209,7 @@ class Music(KodiDb):
 
     @stop()
     @jellyfin_item()
+    @library_check()
     def song(self, item, e_item):
 
         ''' Update object to kodi.


### PR DESCRIPTION
Fixes #270 (and maybe #122)

The `library_check()` decorator verifies that the library ID is in the local synced library list before moving forward.  Adding it to the `song()` function stops cascading failures in `song_artist_discography()` and `song_artist_link()`.  Albums don't need this since their inheritance seem to be more tightly tied to the artist, which is created first.