### PR TITLE
Handle empty list of updates from server

### DIFF
--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -396,7 +396,7 @@ class Library(threading.Thread):
             # Get list of updates from server for synced library types and populate work queues
             result = self.server.jellyfin.get_sync_queue(last_sync, ",".join([ x for x in query_filter ]))
             
-            if result == None:
+            if result is None:
                 return True
             
             updated = []

--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -393,12 +393,16 @@ class Library(threading.Thread):
         query_filter = list(set(filters) - set(include))
 
         try:
+            # Get list of updates from server for synced library types and populate work queues
+            result = self.server.jellyfin.get_sync_queue(last_sync, ",".join([ x for x in query_filter ]))
+            
+            if result == None:
+                return True
+            
             updated = []
             userdata = []
             removed = []
-
-            # Get list of updates from server for synced library types and populate work queues
-            result = self.server.jellyfin.get_sync_queue(last_sync, ",".join([ x for x in query_filter ]))
+            
             updated.extend(result['ItemsAdded'])
             updated.extend(result['ItemsUpdated'])
             userdata.extend(result['UserDataChanged'])


### PR DESCRIPTION
Fixes "Failed to retrieve latest content updates. No content updates will be applied until Kodi is restarted. (...)" on every start up.
