### PR TITLE
Remove whitespace in setup xbmcgui dialogs

### DIFF
--- a/jellyfin_kodi/dialogs/servermanual.py
+++ b/jellyfin_kodi/dialogs/servermanual.py
@@ -59,7 +59,7 @@ class ServerManual(xbmcgui.WindowXMLDialog):
         self.cancel_button = self.getControl(CANCEL)
         self.error_toggle = self.getControl(ERROR_TOGGLE)
         self.error_msg = self.getControl(ERROR_MSG)
-        self.host_field = self._add_editcontrol(755, 433, 40, 415)
+        self.host_field = self._add_editcontrol(755, 490, 40, 415)
 
         self.setFocus(self.host_field)
 

--- a/resources/skins/default/1080i/script-jellyfin-connect-server-manual.xml
+++ b/resources/skins/default/1080i/script-jellyfin-connect-server-manual.xml
@@ -25,7 +25,7 @@
 				<centerleft>50%</centerleft>
 				<centertop>50%</centertop>
 				<width>470</width>
-				<height>470</height>
+				<height>360</height>
 				<control type="group">
 					<top>-30</top>
 					<control type="image">
@@ -38,14 +38,14 @@
 				</control>
 				<control type="image">
 					<width>100%</width>
-					<height>470</height>
+					<height>360</height>
 					<texture colordiffuse="ff222326" border="10">dialogs/dialog_back.png</texture>
 				</control>
 				<control type="group">
 					<centerleft>50%</centerleft>
 					<top>10</top>
 					<width>460</width>
-					<height>470</height>
+					<height>350</height>
 					<control type="grouplist" id="100">
 						<orientation>vertical</orientation>
 						<itemgap>0</itemgap>
@@ -117,7 +117,7 @@
 					</control>
 				</control>
 				<control type="group" id="202">
-					<top>470</top>
+					<top>360</top>
 					<visible>false</visible>
 					<control type="image">
 						<description>Error box</description>

--- a/resources/skins/default/1080i/script-jellyfin-connect-server.xml
+++ b/resources/skins/default/1080i/script-jellyfin-connect-server.xml
@@ -25,7 +25,7 @@
 				<centerleft>50%</centerleft>
 				<centertop>50%</centertop>
 				<width>520</width>
-				<height>525</height>
+				<height>470</height>
 				<control type="group">
 					<top>-30</top>
 					<control type="image">
@@ -45,14 +45,14 @@
 				</control>
 				<control type="image">
 					<width>100%</width>
-					<height>525</height>
+					<height>470</height>
 					<texture colordiffuse="ff222326" border="10">dialogs/dialog_back.png</texture>
 				</control>
 				<control type="group">
 					<centerleft>50%</centerleft>
 					<top>10</top>
 					<width>510</width>
-					<height>515</height>
+					<height>460</height>
 					<control type="grouplist" id="100">
 						<orientation>vertical</orientation>
 						<itemgap>0</itemgap>
@@ -199,7 +199,7 @@
 					</control>
 				</control>
 				<control type="group" id="202">
-					<top>525</top>
+					<top>470</top>
 					<visible>false</visible>
 					<control type="image">
 						<width>100%</width>


### PR DESCRIPTION
Remove whitespace in the initial setup dialogs. These were mostly left over from Emby Connect functionality. Sorry for the messy screenshots with strange scaling.

| Before | After |
|----------|--------|
| ![pre-1](https://user-images.githubusercontent.com/19383474/89725179-b5c93780-d9c1-11ea-9882-294f089e02dc.png) | ![post-1](https://user-images.githubusercontent.com/19383474/89725184-be217280-d9c1-11ea-80d6-d09107d72b94.png) |
| ![pre-2](https://user-images.githubusercontent.com/19383474/89725182-b8c42800-d9c1-11ea-91e4-84d0270a0694.png) | ![post-2](https://user-images.githubusercontent.com/19383474/89725186-bfeb3600-d9c1-11ea-935b-b55ef9c40907.png) |
| ![pre-3](https://user-images.githubusercontent.com/19383474/89725183-ba8deb80-d9c1-11ea-8206-c253f38648ac.png) | ![post-3](https://user-images.githubusercontent.com/19383474/89725187-c11c6300-d9c1-11ea-99fc-5b5a85ea9dd4.png) |
