### PR TITLE
Refactor metadata ancestor gathering

### DIFF
--- a/jellyfin_kodi/database/jellyfin_db.py
+++ b/jellyfin_kodi/database/jellyfin_db.py
@@ -105,13 +105,9 @@ class JellyfinDatabase():
 
     def get_view_name(self, item_id):
 
-        try:
-            self.cursor.execute(QU.get_view_name, (item_id,))
+        self.cursor.execute(QU.get_view_name, (item_id,))
 
-            return self.cursor.fetchone()[0]
-        except Exception as error:
-            LOG.exception(error)
-            return
+        return self.cursor.fetchone()[0]
 
     def get_view(self, *args):
 

--- a/jellyfin_kodi/database/queries.py
+++ b/jellyfin_kodi/database/queries.py
@@ -102,8 +102,8 @@ add_reference_pool_obj = ["{SeriesId}", "{ShowId}", None, "{PathId}", "Series", 
 add_reference_episode_obj = ["{Id}", "{EpisodeId}", "{FileId}", "{PathId}", "Episode", "episode", "{SeasonId}", "{Checksum}", None, "{JellyfinParentId}"]
 add_reference_mvideo_obj = ["{Id}", "{MvideoId}", "{FileId}", "{PathId}", "MusicVideo", "musicvideo", None, "{Checksum}", "{LibraryId}", "{JellyfinParentId}"]
 add_reference_artist_obj = ["{Id}", "{ArtistId}", None, None, "{ArtistType}", "artist", None, "{Checksum}", "{LibraryId}", "{JellyfinParentId}"]
-add_reference_album_obj = ["{Id}", "{AlbumId}", None, None, "MusicAlbum", "album", None, "{Checksum}", None, "{JellyfinParentId}"]
-add_reference_song_obj = ["{Id}", "{SongId}", None, "{PathId}", "Audio", "song", "{AlbumId}", "{Checksum}", None, "{JellyfinParentId}"]
+add_reference_album_obj = ["{Id}", "{AlbumId}", None, None, "MusicAlbum", "album", None, "{Checksum}", "{LibraryId}", "{JellyfinParentId}"]
+add_reference_song_obj = ["{Id}", "{SongId}", None, "{PathId}", "Audio", "song", "{AlbumId}", "{Checksum}", "{LibraryId}", "{JellyfinParentId}"]
 add_view = """
 INSERT OR REPLACE INTO      view(view_id, view_name, media_type)
 VALUES                      (?, ?, ?)

--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -672,28 +672,25 @@ class UserDataWorker(threading.Thread):
                 except Queue.Empty:
                     break
 
-                # Verify that the updated item is in our local whitelist
-                library = find_library(self.server, item)
-                if library:
-                    default_args = (self.server, jellyfindb, kodidb, self.direct_path, library)
-                    try:
-                        if item['Type'] == 'Movie':
-                            Movies(*default_args).userdata(item)
-                        elif item['Type'] in ['Series', 'Season', 'Episode']:
-                            TVShows(*default_args).userdata(item)
-                        elif item['Type'] == 'MusicAlbum':
-                            Music(*default_args).album(item)
-                        elif item['Type'] == 'MusicArtist':
-                            Music(*default_args).artist(item)
-                        elif item['Type'] == 'AlbumArtist':
-                            Music(*default_args).albumartist(item)
-                        elif item['Type'] == 'Audio':
-                            Music(*default_args).song(item)
-                    except LibraryException as error:
-                        if error.status == 'StopCalled':
-                            break
-                    except Exception as error:
-                        LOG.exception(error)
+                default_args = (self.server, jellyfindb, kodidb, self.direct_path)
+                try:
+                    if item['Type'] == 'Movie':
+                        Movies(*default_args).userdata(item)
+                    elif item['Type'] in ['Series', 'Season', 'Episode']:
+                        TVShows(*default_args).userdata(item)
+                    elif item['Type'] == 'MusicAlbum':
+                        Music(*default_args).album(item)
+                    elif item['Type'] == 'MusicArtist':
+                        Music(*default_args).artist(item)
+                    elif item['Type'] == 'AlbumArtist':
+                        Music(*default_args).albumartist(item)
+                    elif item['Type'] == 'Audio':
+                        Music(*default_args).userdata(item)
+                except LibraryException as error:
+                    if error.status == 'StopCalled':
+                        break
+                except Exception as error:
+                    LOG.exception(error)
 
                 self.queue.task_done()
 

--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -16,7 +16,7 @@ from full_sync import FullSync
 from views import Views
 from downloader import GetItemWorker
 from helper import translate, api, stop, settings, window, dialog, event
-from helper.utils import split_list, set_screensaver, get_screensaver, find_library
+from helper.utils import split_list, set_screensaver, get_screensaver
 from helper.exceptions import LibraryException
 from jellyfin import Jellyfin
 from helper import LazyLogger
@@ -605,39 +605,37 @@ class UpdateWorker(threading.Thread):
                 except Queue.Empty:
                     break
 
-                # Verify that the updated item is in our local whitelist
-                library = find_library(self.server, item)
-                if library:
-                    default_args = (self.server, jellyfindb, kodidb, self.direct_path, library)
-                    try:
-                        if item['Type'] == 'Movie':
-                            Movies(*default_args).movie(item)
-                        elif item['Type'] == 'BoxSet':
-                            Movies(*default_args).boxset(item)
-                        elif item['Type'] == 'Series':
-                            TVShows(*default_args).tvshow(item)
-                        elif item['Type'] == 'Season':
-                            TVShows(*default_args).season(item)
-                        elif item['Type'] == 'Episode':
-                            TVShows(*default_args).episode(item)
-                        elif item['Type'] == 'MusicVideo':
-                            MusicVideos(*default_args).musicvideo(item)
-                        elif item['Type'] == 'MusicAlbum':
-                            Music(*default_args).album(item)
-                        elif item['Type'] == 'MusicArtist':
-                            Music(*default_args).artist(item)
-                        elif item['Type'] == 'AlbumArtist':
-                            Music(*default_args).albumartist(item)
-                        elif item['Type'] == 'Audio':
-                            Music(*default_args).song(item)
+                default_args = (self.server, jellyfindb, kodidb, self.direct_path)
+                try:
+                    LOG.info('{} - {}'.format(item['Type'], item['Name']))
+                    if item['Type'] == 'Movie':
+                        Movies(*default_args).movie(item)
+                    elif item['Type'] == 'BoxSet':
+                        Movies(*default_args).boxset(item)
+                    elif item['Type'] == 'Series':
+                        TVShows(*default_args).tvshow(item)
+                    elif item['Type'] == 'Season':
+                        TVShows(*default_args).season(item)
+                    elif item['Type'] == 'Episode':
+                        TVShows(*default_args).episode(item)
+                    elif item['Type'] == 'MusicVideo':
+                        MusicVideos(*default_args).musicvideo(item)
+                    elif item['Type'] == 'MusicAlbum':
+                        Music(*default_args).album(item)
+                    elif item['Type'] == 'MusicArtist':
+                        Music(*default_args).artist(item)
+                    elif item['Type'] == 'AlbumArtist':
+                        Music(*default_args).albumartist(item)
+                    elif item['Type'] == 'Audio':
+                        Music(*default_args).song(item)
 
-                        if self.notify:
-                            self.notify_output.put((item['Type'], api.API(item).get_naming()))
-                    except LibraryException as error:
-                        if error.status == 'StopCalled':
-                            break
-                    except Exception as error:
-                        LOG.exception(error)
+                    if self.notify:
+                        self.notify_output.put((item['Type'], api.API(item).get_naming()))
+                except LibraryException as error:
+                    if error.status == 'StopCalled':
+                        break
+                except Exception as error:
+                    LOG.exception(error)
 
                 self.queue.task_done()
 

--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -607,7 +607,7 @@ class UpdateWorker(threading.Thread):
 
                 default_args = (self.server, jellyfindb, kodidb, self.direct_path)
                 try:
-                    LOG.info('{} - {}'.format(item['Type'], item['Name']))
+                    LOG.debug('{} - {}'.format(item['Type'], item['Name']))
                     if item['Type'] == 'Movie':
                         Movies(*default_args).movie(item)
                     elif item['Type'] == 'BoxSet':

--- a/jellyfin_kodi/objects/musicvideos.py
+++ b/jellyfin_kodi/objects/musicvideos.py
@@ -12,6 +12,7 @@ from kodi_six.utils import py2_encode
 from database import jellyfin_db, queries as QUEM
 from helper import api, stop, validate, jellyfin_item, values, Local
 from helper import LazyLogger
+from helper.utils import find_library
 from helper.exceptions import PathValidationException
 
 from .obj import Objects
@@ -59,10 +60,20 @@ class MusicVideos(KodiDb):
             obj['MvideoId'] = e_item[0]
             obj['FileId'] = e_item[1]
             obj['PathId'] = e_item[2]
+            obj['LibraryId'] = e_item[6]
+            obj['LibraryName'] = self.jellyfin_db.get_view_name(obj['LibraryId'])
         except TypeError:
             update = False
+
+            library = self.library or find_library(self.server, item)
+            if not library:
+                # This item doesn't belong to a whitelisted library
+                return
+
             LOG.debug("MvideoId for %s not found", obj['Id'])
             obj['MvideoId'] = self.create_entry()
+            obj['LibraryId'] = library['Id']
+            obj['LibraryName'] = library['Name']
         else:
             if self.get(*values(obj, QU.get_musicvideo_obj)) is None:
 


### PR DESCRIPTION
Kinda fixes #361. Some of it just can't be helped.  We don't need to find ancestors on userdata updates.  If the item exists, it's updated. If it doesn't, it gets skipped.  No need to do the intensive lookup process.

I'm not sure the Artist/Album bits of the userdata updates are ever triggered.  At least I haven't seen it in my testing, but I'm not confident enough to remove it yet.

Also changes
```
Music(*default_args).song(item)
```
to
```
Music(*default_args).userdata(item)
```
We don't want to try to add new items whenever a song is listened to