### PR TITLE
Publish artifacts in pipeline

### DIFF
--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -25,6 +25,12 @@ steps:
         tarCompression: 'none'
         archiveFile: '$(Build.ArtifactStagingDirectory)/plugin.video.jellyfin-${{ py_version }}.zip'
 
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish ${{ py_version }} artifact'
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)/plugin.video.jellyfin-${{ py_version }}.zip'
+        artifactName: 'plugin.video.jellyfin-${{ py_version }}-$(Build.BuildNumber).zip'
+
     - task: CopyFilesOverSSH@0
       displayName: 'Upload to repo server'
       inputs:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -23,13 +23,13 @@ steps:
         includeRootFolder: False
         archiveType: 'zip'
         tarCompression: 'none'
-        archiveFile: 'plugin.video.jellyfin-${{ py_version }}.zip'
+        archiveFile: '$(Build.ArtifactStagingDirectory)/plugin.video.jellyfin-${{ py_version }}.zip'
 
     - task: CopyFilesOverSSH@0
       displayName: 'Upload to repo server'
       inputs:
         sshEndpoint: repository
-        sourceFolder: '${Agent.BuildDirectory}'
+        sourceFolder: '$(Build.ArtifactStagingDirectory)'
         contents: 'plugin.video.jellyfin-${{ py_version }}.zip'
         targetFolder: '/srv/repository/incoming/kodi'
       condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')


### PR DESCRIPTION
Changes the build pipeline to publish the built zip files in azure to make it easier to download/test PRs

Edit: example - https://dev.azure.com/jellyfin-project/jellyfin/_build/results?buildId=12569&view=artifacts&type=publishedArtifacts