### PR TITLE
Add more transcoding options

### DIFF
--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -319,6 +319,9 @@ class PlayUtils(object):
         if settings('transcode_mpeg2.bool'):
             codecs.remove('mpeg2video')
 
+        if settings('transcode_vc1.bool'):
+            codecs.remove('vc1')
+
         return ','.join(codecs)
 
     def get_transcoding_video_codec(self):
@@ -333,6 +336,9 @@ class PlayUtils(object):
 
         if settings('transcode_mpeg2.bool'):
             codecs.remove('mpeg2video')
+
+        if settings('transcode_vc1.bool'):
+            codecs.remove('vc1')
 
         return ','.join(codecs)
 

--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -526,6 +526,23 @@ class PlayUtils(object):
 
         return path
 
+    def get_commercial_codec_name(self, codec, profile):
+        NAMES = {
+            'ac3': 'Dolby Digital',
+            'eac3': 'Dolby Digital+',
+            'truehd': 'Dolby TrueHD',
+            'dts': 'DTS'
+        }
+
+        if profile == 'DTS-HD MA':
+            return 'DTS-HD Master Audio'
+        if profile == 'DTS-HD HRA':
+            return 'DTS-HD High Resolution Audio'
+        if codec in NAMES:
+            return NAMES[codec]
+
+        return codec.upper()
+
     def get_audio_subs(self, source, audio=None, subtitle=None):
 
         ''' For transcoding only
@@ -546,22 +563,24 @@ class PlayUtils(object):
 
             if stream_type == 'Audio':
 
-                codec = stream['Codec']
-                channel = stream.get('ChannelLayout', "")
+                profile = stream['Profile'] if 'Profile' in stream else None
+                codec = self.get_commercial_codec_name(stream['Codec'], profile)
+                channel = stream.get('ChannelLayout', "").capitalize()
 
                 if 'Language' in stream:
-                    track = "%s - %s - %s %s" % (index, stream['Language'], codec, channel)
+                    track = "%s - %s %s" % (stream['Language'].capitalize(), codec, channel)
                 else:
-                    track = "%s - %s %s" % (index, codec, channel)
+                    track = "%s %s" % (codec, channel)
 
                 audio_streams[track] = index
 
             elif stream_type == 'Subtitle':
+                codec = self.get_commercial_codec_name(stream['Codec'], None)
 
                 if 'Language' in stream:
-                    track = "%s - %s" % (index, stream['Language'])
+                    track = "%s - %s" % (stream['Language'].capitalize(), codec)
                 else:
-                    track = "%s - %s" % (index, stream['Codec'])
+                    track = "%s" % codec
 
                 if stream['IsDefault']:
                     track = "%s - Default" % track

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -74,8 +74,28 @@ msgid "Enable enhanced artwork (i.e. cover art)"
 msgstr "Enable enhanced artwork (i.e. cover art)"
 
 msgctxt "#30160"
-msgid "Video quality"
-msgstr "Video quality"
+msgid "Max stream bitrate"
+msgstr "Max stream bitrate"
+
+msgctxt "#30161"
+msgid "Preferred video codec"
+msgstr "Preferred video codec"
+
+msgctxt "#30162"
+msgid "Preferred audio codec"
+msgstr "Preferred audio codec"
+
+msgctxt "#30163"
+msgid "Audio bitrate"
+msgstr "Audio bitrate"
+
+msgctxt "#30164"
+msgid "Audio max channels"
+msgstr "Audio max channels"
+
+msgctxt "#30165"
+msgid "Allow burned subtitles"
+msgstr "Allow burned subtitles"
 
 msgctxt "#30170"
 msgid "Recently Added TV Shows"
@@ -276,6 +296,10 @@ msgstr "Jump back on resume (in seconds)"
 msgctxt "#30522"
 msgid "Transcode H265/HEVC"
 msgstr "Transcode H265/HEVC"
+
+msgctxt "#30523"
+msgid "Transcode MPEG2"
+msgstr "Transcode MPEG2"
 
 msgctxt "#30527"
 msgid "Ignore specials in next episodes"
@@ -613,8 +637,8 @@ msgid "Enable external subtitles"
 msgstr "Enable external subtitles"
 
 msgctxt "#33115"
-msgid "Adjust for remote connection"
-msgstr "Adjust for remote connection"
+msgid "Transcode options"
+msgstr "Transcode options"
 
 msgctxt "#33116"
 msgid "Compress artwork (reduces quality)"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -301,6 +301,10 @@ msgctxt "#30523"
 msgid "Transcode MPEG2"
 msgstr "Transcode MPEG2"
 
+msgctxt "#30524"
+msgid "Transcode VC-1"
+msgstr "Transcode VC-1"
+
 msgctxt "#30527"
 msgid "Ignore specials in next episodes"
 msgstr "Ignore specials in next episodes"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -38,12 +38,20 @@
 		<setting label="30519" id="askCinema" type="bool" default="false" visible="eq(-1,true)" subsetting="true" />
 		<setting label="30002" id="playFromStream" type="bool" default="true" />
 		<setting label="33179" id="playFromTranscode" type="bool" default="false" visible="eq(-1,true)" subsetting="true" />
-	    <setting label="30522" id="transcode_h265" type="bool" default="false" visible="eq(-1,false)" />
-	    <setting label="30537" id="transcodeHi10P" type="bool" default="false" visible="eq(-2,false)" />
+	    <setting label="30160" id="maxBitrate" type="enum" values="0.5 Mbps|1 Mbps|1.5 Mbps|2.0 Mbps|2.5 Mbps|3.0 Mbps|4.0 Mbps|5.0 Mbps|6.0 Mbps|7.0 Mbps|8.0 Mbps|9.0 Mbps|10.0 Mbps|12.0 Mbps|14.0 Mbps|16.0 Mbps|18.0 Mbps|20.0 Mbps|25.0 Mbps|30.0 Mbps|35.0 Mbps|40.0 Mbps|100.0 Mbps [default]|1000.0 Mbps" visible="true" default="22" />
 	    <setting label="33114" id="enableExternalSubs" type="bool" default="true" />
+
+		<setting type="sep" />
+		<setting label="33115" type="lsep" />
+	    <setting label="30537" id="transcodeHi10P" type="bool" default="false" visible="true" />
+	    <setting label="30522" id="transcode_h265" type="bool" default="false" visible="true" />
+	    <setting label="30523" id="transcode_mpeg2" type="bool" default="false" visible="true" />
+	    <setting label="30161" id="videoPreferredCodec" type="select" values="H264/AVC|H265/HEVC" visible="eq(-2,false)" default="H264/AVC" />
+	    <setting label="30162" id="audioPreferredCodec" type="select" values="AAC|AC3|MP3|Opus|FLAC|Vorbis" visible="true" default="AAC" />
+	    <setting label="30163" id="audioBitrate" type="enum" values="96|128|160|192|256|320|384" visible="true" default="4" />
+	    <setting label="30164" id="audioMaxChannels" type="slider" range="2,1,6" option="int" visible="true" default="6" />
 	    <setting label="33159" id="skipDialogTranscode" type="enum" lvalues="305|33157|33158|13106" visible="true" default="3" />
-	    <setting label="33115" type="lsep" />
-	    <setting label="30160" id="videoBitrate" type="enum" values="664 Kbps SD|996 Kbps HD|1.3 Mbps HD|2.0 Mbps HD|3.2 Mbps HD|4.7 Mbps HD|6.2 Mbps HD|7.7 Mbps HD|9.2 Mbps HD|10.7 Mbps HD|12.2 Mbps HD|13.7 Mbps HD|15.2 Mbps HD|16.7 Mbps HD|18.2 Mbps HD|20.0 Mbps HD|25.0 Mbps HD|30.0 Mbps HD|35.0 Mbps HD|40.0 Mbps HD|100.0 Mbps HD [default]|1000.0 Mbps HD" visible="true" default="20" />
+	    <setting label="30165" id="allowBurnedSubs" type="bool" visible="true" enable="true" default="true" />
 
 		<setting type="sep" />
 		<setting label="33112" type="lsep" />

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -46,6 +46,7 @@
 	    <setting label="30537" id="transcodeHi10P" type="bool" default="false" visible="true" />
 	    <setting label="30522" id="transcode_h265" type="bool" default="false" visible="true" />
 	    <setting label="30523" id="transcode_mpeg2" type="bool" default="false" visible="true" />
+	    <setting label="30524" id="transcode_vc1" type="bool" default="false" visible="true" />
 	    <setting label="30161" id="videoPreferredCodec" type="select" values="H264/AVC|H265/HEVC" visible="eq(-2,false)" default="H264/AVC" />
 	    <setting label="30162" id="audioPreferredCodec" type="select" values="AAC|AC3|MP3|Opus|FLAC|Vorbis" visible="true" default="AAC" />
 	    <setting label="30163" id="audioBitrate" type="enum" values="96|128|160|192|256|320|384" visible="true" default="4" />


### PR DESCRIPTION
I made these changes mostly for my personal use, but I'm parking them here in case someone deems them useful, and perhaps could review them and/or help me test them more extensively.

Anyway, this PR adds more transcoding options to the Settings menu, such as preferred transcoding codec for video/audio, manual bitrate options, max audio channels, and few other changes (described in commit messages).

Max. audio bitrate while transcoding/direct streaming seems to be limited by the backend to [384 kbps](https://github.com/jellyfin/jellyfin/blob/master/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs#L1370), just like max. channels are [limited to 6](https://github.com/jellyfin/jellyfin/blob/master/MediaBrowser.Controller/MediaEncoding/EncodingHelper.cs#L1459). Transcoding to AC3 could benefit from allowing up to 640 kbps, but that needs to be dealt with on the server side first.