### PR TITLE
Add an option to reduce max artwork resolution

### DIFF
--- a/jellyfin_kodi/helper/api.py
+++ b/jellyfin_kodi/helper/api.py
@@ -263,6 +263,11 @@ class API(object):
         if not settings('enableCoverArt.bool'):
             query += "&EnableImageEnhancers=false"
 
+        art_maxheight = [360, 480, 600, 720, 1080, -1]
+        maxheight = art_maxheight[int(settings('maxArtResolution') or 5)]
+        if maxheight != -1:
+            query += "&MaxHeight=%d" % maxheight
+
         all_artwork['Backdrop'] = self.get_backdrops(obj['Id'], obj['BackdropTags'] or [], query)
 
         for artwork in (obj['Tags'] or []):

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -944,3 +944,7 @@ msgstr "Select the libraries to repair"
 msgctxt "#33200"
 msgid "Select the libraries to remove"
 msgstr "Select the libraries to remove"
+
+msgctxt "#33201"
+msgid "Max artwork resolution"
+msgstr "Max artwork resolution"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -29,6 +29,7 @@
 		<setting label="33176" type="lsep" />
 		<setting label="30157" id="enableCoverArt" type="bool" default="true" />
 		<setting label="33116" id="compressArt" type="bool" default="false" />
+		<setting label="33201" id="maxArtResolution" type="enum" values="360|480|600|720|1080|Unlimited [default]" default="5" />
 		<setting id="enableMusic" visible="false" default="false" />
 	</category>
 	


### PR DESCRIPTION
This PR adds "Max artwork resolution" option to the "Sync options" section in Jellyfin settings.
Changing this will limit the resolution of pulled media artwork (posters, backdrops, etc...), based on the specified max. height.

Options are: 360, 480, 600, 720, 1080, Unlimited
By default it is set to Unlimited (same as it was before)

Lowering the maximum resolution (e.g. to 600, or even 480) significantly improves scrolling speed/perf/smoothness (esp. in poster widgets) on low-power devices, such as the RPi3. Library resync is required to reflect any change, just like for any of the other options (Compress artwork, ...).