### PR TITLE
Don't force-extract subs for transcoded content

### DIFF
--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -509,8 +509,13 @@ class PlayUtils(object):
         mapping = {}
         kodi = 0
 
+        server_settings = TheVoid('GetTranscodeOptions', {'ServerId': self.info['ServerId']}).get()
+
         for stream in source['MediaStreams']:
-            if stream['Type'] == 'Subtitle' and stream['DeliveryMethod'] == 'External':
+            if stream['SupportsExternalStream'] and stream['Type'] == 'Subtitle' and stream['DeliveryMethod'] == 'External':
+                if not stream['IsExternal'] and not server_settings['EnableSubtitleExtraction']:
+                    continue
+
                 index = stream['Index']
                 url = self.get_subtitles(source, stream, index)
 

--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -598,6 +598,7 @@ class PlayUtils(object):
         subs_streams = collections.OrderedDict()
         streams = source['MediaStreams']
 
+        server_settings = TheVoid('GetTranscodeOptions', {'ServerId': self.info['ServerId']}).get()
         allow_burned_subs = settings('allowBurnedSubs.bool')
 
         for stream in streams:
@@ -619,9 +620,13 @@ class PlayUtils(object):
                 audio_streams[track] = index
 
             elif stream_type == 'Subtitle':
-                downloadable = stream['IsTextSubtitleStream'] and stream['IsExternal'] and stream['SupportsExternalStream']
-                if not downloadable and not allow_burned_subs:
-                    continue
+                if stream['IsExternal']:
+                    if not stream['SupportsExternalStream'] and not allow_burned_subs:
+                        continue
+                else:
+                    avail_for_extraction = stream['SupportsExternalStream'] and server_settings['EnableSubtitleExtraction']
+                    if not avail_for_extraction and not allow_burned_subs:
+                        continue
 
                 codec = self.get_commercial_codec_name(stream['Codec'], None)
 
@@ -660,7 +665,6 @@ class PlayUtils(object):
         if subtitle:
 
             index = subtitle
-            server_settings = TheVoid('GetTranscodeOptions', {'ServerId': self.info['ServerId']}).get()
             stream = streams[index]
 
             if server_settings['EnableSubtitleExtraction'] and stream['SupportsExternalStream']:
@@ -679,8 +683,6 @@ class PlayUtils(object):
                 index = subs_streams[selection[resp]] if resp > -1 else source.get('DefaultSubtitleStreamIndex')
 
                 if index is not None:
-
-                    server_settings = TheVoid('GetTranscodeOptions', {'ServerId': self.info['ServerId']}).get()
                     stream = streams[index]
 
                     if server_settings['EnableSubtitleExtraction'] and stream['SupportsExternalStream']:


### PR DESCRIPTION
#399 broke playback of transcoded content with embedded subs. Kodi now waits for all embedded subs to be extracted while ignoring 'Allow subtitle extraction on the fly' server option.

On my instance, the playback won't start for about 20 minutes, until the subs are finished extracting (even if the option is disabled in the server dashboard).

See my comment here: https://github.com/jellyfin/jellyfin-kodi/pull/399#issuecomment-718810945

This PR also adds embedded subs to the list of available sub tracks in the audio/subs selection dialog (the one shown before playback starts), if the aforementioned option is enabled on your jellyfin server. Furthemore, now subs that don't have 'SupportsExternalStream' set to true are also ignored and not shown as external in the video player OSD sub selection (those can't be extracted, if I'm not mistaken) - such as embedded PGS.