### PR TITLE
Move api_client details to context.py

### DIFF
--- a/jellyfin_kodi/entrypoint/context.py
+++ b/jellyfin_kodi/entrypoint/context.py
@@ -52,6 +52,19 @@ class Context(object):
                 self.media = xbmc.getInfoLabel('ListItem.DBTYPE')
                 item_id = None
 
+        addon_data = xbmc.translatePath("special://profile/addon_data/plugin.video.jellyfin/data.json")
+        with open(addon_data, 'rb') as infile:
+            data = json.load(infile)
+
+        try:
+            server_data = data['Servers'][0]
+            self.api_client.config.data['auth.server'] = server_data.get('address')
+            self.api_client.config.data['auth.server-name'] = server_data.get('Name')
+            self.api_client.config.data['auth.user_id'] = server_data.get('UserId')
+            self.api_client.config.data['auth.token'] = server_data.get('AccessToken')
+        except Exception as e:
+            LOG.warning('Addon appears to not be configured yet: {}'.format(e))
+
         if self.server_id or item_id:
             self.item = self.api_client.get_item(item_id)
         else:

--- a/jellyfin_kodi/jellyfin/client.py
+++ b/jellyfin_kodi/jellyfin/client.py
@@ -3,10 +3,7 @@ from __future__ import division, absolute_import, print_function, unicode_litera
 
 #################################################################################################
 
-import json
-
 from helper import LazyLogger
-from kodi_six.xbmc import translatePath
 
 from . import api
 from .configuration import Config
@@ -44,19 +41,6 @@ class JellyfinClient(object):
         self.jellyfin = api.API(self.http)
         self.callback_ws = callback
         self.callback = callback
-
-        addon_data = translatePath("special://profile/addon_data/plugin.video.jellyfin/data.json")
-        with open(addon_data, 'rb') as infile:
-            data = json.load(infile)
-
-        try:
-            server_data = data['Servers'][0]
-            self.jellyfin.config.data['auth.server'] = server_data.get('address')
-            self.jellyfin.config.data['auth.server-name'] = server_data.get('Name')
-            self.jellyfin.config.data['auth.user_id'] = server_data.get('UserId')
-            self.jellyfin.config.data['auth.token'] = server_data.get('AccessToken')
-        except Exception as e:
-            LOG.warning('Addon appears to not be configured yet: {}'.format(e))
 
     def set_credentials(self, credentials=None):
         self.auth.credentials.set_credentials(credentials or {})


### PR DESCRIPTION
Follow up to #434.  Moves the auth details into `entrypoint/context.py`.  Allows first time setup to complete and should let anything under `Jellyfin options` in the context menu complete