### PR TITLE
Stop autodiscovered servers overriding manual input

### DIFF
--- a/jellyfin_kodi/connect.py
+++ b/jellyfin_kodi/connect.py
@@ -176,6 +176,7 @@ class Connect(object):
             LOG.debug("Adding manual server")
             try:
                 self.manual_server()
+                return
             except RuntimeError:
                 pass
         else:

--- a/jellyfin_kodi/connect.py
+++ b/jellyfin_kodi/connect.py
@@ -112,8 +112,7 @@ class Connect(object):
                 return state['Credentials']
 
             elif (server_selection or state['State'] == CONNECTION_STATE['ServerSelection'] or state['State'] == CONNECTION_STATE['Unavailable'] and not settings('SyncInstallRunDone.bool')):
-
-                self.select_servers(state)
+                state['Credentials']['Servers'] = [self.select_servers(state)]
 
             elif state['State'] == CONNECTION_STATE['ServerSignIn']:
                 if 'ExchangeToken' not in state['Servers'][0]:
@@ -170,13 +169,12 @@ class Connect(object):
 
         if dialog.is_server_selected():
             LOG.debug("Server selected: %s", dialog.get_server())
-            return
+            return dialog.get_server()
 
         elif dialog.is_manual_server():
             LOG.debug("Adding manual server")
             try:
-                self.manual_server()
-                return
+                return self.manual_server()
             except RuntimeError:
                 pass
         else:

--- a/resources/skins/default/1080i/script-jellyfin-connect-server.xml
+++ b/resources/skins/default/1080i/script-jellyfin-connect-server.xml
@@ -75,7 +75,7 @@
 								<onup>noop</onup>
 								<onleft>close</onleft>
 								<onright>close</onright>
-								<ondown>205</ondown>
+								<ondown>206</ondown>
 								<itemlayout width="510" height="65">
 									<control type="group">
 										<left>20</left>


### PR DESCRIPTION
Fixes #440 (both the manual input and the button the on the selection screen).  When you manually enter a server it now goes directly to the login screen instead of dropping you into the server selection again.

Nothing like multiple hours of digging to change 4 lines, right?