### PR TITLE
Make sure status code gets returned in payload

### DIFF
--- a/jellyfin_kodi/jellyfin/connection_manager.py
+++ b/jellyfin_kodi/jellyfin/connection_manager.py
@@ -318,6 +318,7 @@ class ConnectionManager(object):
                 self._update_server_info(server, system_info)
                 self.config.data['auth.user_id'] = server['UserId']
                 self.config.data['auth.token'] = server['AccessToken']
+                system_info['Status_Code'] = 200
 
                 return self._after_connect_validated(server, credentials, system_info, False, options)
 


### PR DESCRIPTION
Sometimes we reach this code block and haven't gotten a status code, causing errors to get thrown in the logs.

```
2020-12-17 00:16:43.977 T:139776062867008  NOTICE: JELLYFIN.entrypoint.service -> ERROR::jellyfin_kodi/entrypoint/service.py:132 u'Status_Code'
                                            Traceback (most recent call last):
                                              File "jellyfin_kodi/entrypoint/service.py", line 128, in start_default
                                                self.connect.register()
                                              File "jellyfin_kodi/connect.py", line 50, in register
                                                new_credentials = self.register_client(credentials, options, server_id, server_select)
                                              File "jellyfin_kodi/connect.py", line 122, in register_client
                                                elif state['State'] == CONNECTION_STATE['Unavailable'] and state['Status_Code'] == 401:
                                            KeyError: u'Status_Code'
```