### PR TITLE
Fix recently added albums in Kodi 19

### DIFF
--- a/jellyfin_kodi/objects/kodi/music.py
+++ b/jellyfin_kodi/objects/kodi/music.py
@@ -158,8 +158,10 @@ class Music(Kodi):
         album_id = album_id or self.create_entry_album()
         if self.version_id < 72:
             self.cursor.execute(QU.add_album, (album_id,) + args)
-        else:
+        elif self.version_id < 82:
             self.cursor.execute(QU.add_album72, (album_id,) + args)
+        else:
+            self.cursor.execute(QU.add_album82, (album_id,) + args)
         return album_id
 
     def update_album(self, *args):

--- a/jellyfin_kodi/objects/kodi/queries_music.py
+++ b/jellyfin_kodi/objects/kodi/queries_music.py
@@ -54,7 +54,7 @@ FROM        album
 WHERE       strMusicBrainzAlbumID = ?
 """
 get_album_obj = ["{AlbumId}", "{Title}", "{UniqueId}", "{Artists}", "album"]
-get_album_obj82 = ["{AlbumId}", "{Title}", "{UniqueId}", "{Artists}", "album", "{dateAdded}"]
+get_album_obj82 = ["{AlbumId}", "{Title}", "{UniqueId}", "{Artists}", "album", "{DateAdded}"]
 get_album_by_name = """
 SELECT      idAlbum, strArtists
 FROM        album
@@ -102,7 +102,7 @@ INSERT INTO     album(idAlbum, strAlbum, strMusicBrainzAlbumID, strReleaseType, 
 VALUES          (?, ?, ?, ?, 1)
 """
 add_album82 = """
-INSERT INTO     album(idAlbum, strAlbum, strMusicBrainzAlbumID, strReleaseType, bScrapedMBID, dateAdded)
+INSERT INTO     album(idAlbum, strAlbum, strMusicBrainzAlbumID, strReleaseType, bScrapedMBID, DateAdded)
 VALUES          (?, ?, ?, ?, 1, ?)
 """
 add_single = """

--- a/jellyfin_kodi/objects/kodi/queries_music.py
+++ b/jellyfin_kodi/objects/kodi/queries_music.py
@@ -54,6 +54,7 @@ FROM        album
 WHERE       strMusicBrainzAlbumID = ?
 """
 get_album_obj = ["{AlbumId}", "{Title}", "{UniqueId}", "{Artists}", "album"]
+get_album_obj82 = ["{AlbumId}", "{Title}", "{UniqueId}", "{Artists}", "album", "{dateAdded}"]
 get_album_by_name = """
 SELECT      idAlbum, strArtists
 FROM        album
@@ -99,6 +100,10 @@ VALUES          (?, ?, ?, ?)
 add_album72 = """
 INSERT INTO     album(idAlbum, strAlbum, strMusicBrainzAlbumID, strReleaseType, bScrapedMBID)
 VALUES          (?, ?, ?, ?, 1)
+"""
+add_album82 = """
+INSERT INTO     album(idAlbum, strAlbum, strMusicBrainzAlbumID, strReleaseType, bScrapedMBID, dateAdded)
+VALUES          (?, ?, ?, ?, 1, ?)
 """
 add_single = """
 INSERT INTO     album(idAlbum, strGenres, iYear, strReleaseType)

--- a/jellyfin_kodi/objects/music.py
+++ b/jellyfin_kodi/objects/music.py
@@ -153,7 +153,7 @@ class Music(KodiDb):
         obj['Artists'] = " / ".join(obj['Artists'] or [])
         obj['Artwork'] = API.get_all_artwork(self.objects.map(item, 'ArtworkMusic'), True)
         obj['Thumb'] = obj['Artwork']['Primary']
-        obj['dateAdded'] = item.get('DateCreated')
+        obj['DateAdded'] = item.get('DateCreated')
 
         if obj['DateAdded']:
             obj['DateAdded'] = Local(obj['DateAdded']).split('.')[0].replace('T', " ")

--- a/jellyfin_kodi/objects/music.py
+++ b/jellyfin_kodi/objects/music.py
@@ -153,6 +153,10 @@ class Music(KodiDb):
         obj['Artists'] = " / ".join(obj['Artists'] or [])
         obj['Artwork'] = API.get_all_artwork(self.objects.map(item, 'ArtworkMusic'), True)
         obj['Thumb'] = obj['Artwork']['Primary']
+        obj['dateAdded'] = item.get('DateCreated')
+
+        if obj['DateAdded']:
+            obj['DateAdded'] = Local(obj['DateAdded']).split('.')[0].replace('T', " ")
 
         if obj['Thumb']:
             obj['Thumb'] = "<thumb>%s</thumb>" % obj['Thumb']
@@ -173,7 +177,11 @@ class Music(KodiDb):
 
         ''' Add object to kodi.
         '''
-        obj['AlbumId'] = self.get_album(*values(obj, QU.get_album_obj))
+        if self.version_id >= 82:
+            obj_values = values(obj, QU.get_album_obj82)
+        else:
+            obj_values = values(obj, QU.get_album_obj)
+        obj['AlbumId'] = self.get_album(*obj_values)
         self.jellyfin_db.add_reference(*values(obj, QUEM.add_reference_album_obj))
         LOG.debug("ADD album [%s] %s: %s", obj['AlbumId'], obj['Title'], obj['Id'])
 


### PR DESCRIPTION
Fixes #481 

In Kodi 19, `dateNew` is auto created when something is added to the database, but `dateAdded` is what's actually used to populate the skin.

This only seems to be an issue on upgraded installs.  Fresh installs largely behave properly, but it would still be out of order sometimes (not sure what actually caused that, but this should fix it too).