### PR TITLE
Speed up sync process

### DIFF
--- a/jellyfin_kodi/objects/kodi/kodi.py
+++ b/jellyfin_kodi/objects/kodi/kodi.py
@@ -160,23 +160,24 @@ class Kodi(object):
         self.cursor.execute(QU.add_person, args)
         return self.cursor.lastrowid
 
-    def _get_person(self, *args):
+    def _get_person(self, name):
         '''Retrieve person from the database, or add them if they don't exist
         '''
-        resp = self.cursor.execute(QU.get_person, args).fetchone()
+        resp = self.cursor.execute(QU.get_person, (name,)).fetchone()
         if resp is not None:
             return resp[0]
         else:
-            return self.add_person(*args)
+            return self.add_person(name)
 
-    def get_person(self, *args):
+    def get_person(self, name):
         '''Retrieve person from cache, else forward to db query
         '''
-        person_id = self._people_cache.get(args)
-        if not person_id:
-            person_id = self._get_person(*args)
-            self._people_cache[args] = person_id
-        return person_id
+        if name in self._people_cache:
+            return self._people_cache[name]
+        else:
+            person_id = self._get_person(name)
+            self._people_cache[name] = person_id
+            return person_id
 
     def add_genres(self, genres, *args):
 


### PR DESCRIPTION
Hello,

lately I had the problem that the "fast sync" wasn't fast at all. I had 300+ changes in my Jellyfin library. It took Kodi about two seconds (sometimes more) per item to update/add it to the Kodi database.

**So the fast sync process of 300+ items took longer than full sync with 2000+ items...**
My thought was that there must be something that slows down the fast sync process. I looked into the code and found two things:

1. During fast sync for every updated item of the Jellyfin library e.g. a `Movies` object is created. See `jellyfin_kodi/library.py`. So I changed this behavior to create the those database objects before the actual processing of the items happens. This speeded up the whole sync process at least a little bit. But the fast sync was still slower compared to a full sync...

2. Actually I stumbled about the second solution by accident. After I commented out some lines in the `movie` method (`jellyfin_kodi/objects/movies.py`) the fast sync now was incredibly fast 👍 
Ok what happend? I tracked it down to the `get_person` method (`jellyfin_kodi/objects/kodi/kodi.py`). To avoid a lot of queries to the Kodi database there was a cache for peoples created in this file. This cache is a dictionary that has the people names as keys and their unique IDs of the Kodi database as values. When querying for a person this cache should be used first, afterwards the Kodi database to get the person ID.
But the problem was that this cache was never used. When looking into the cache the `args` parameter was used as a list, because of the `*`. So the cache was always searched for a list, but it contains only strings as keys. Because of that the person IDs were fetched from the Kodi database with a `SELECT` call. And this slowed down the whole sync process.

A positive side effect of my fix: Not only the fast sync is now really fast, but also the full sync is faster.