### PR TITLE
Fix transcoding of wrong audio channel

### DIFF
--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -641,7 +641,7 @@ class PlayUtils(object):
 
                 selection = list(audio_streams.keys())
                 resp = dialog("select", translate(33013), selection)
-                audio_selected = audio_streams[selection[resp]] if resp else source['DefaultAudioStreamIndex']
+                audio_selected = audio_streams[selection[resp]] if resp > -1 else source['DefaultAudioStreamIndex']
             else:  # Only one choice
                 audio_selected = audio_streams[next(iter(audio_streams))]
         else:


### PR DESCRIPTION
It's a zero based index, so if the first entry is not the default language, you can't ever select it.
Probably related to https://github.com/jellyfin/jellyfin-kodi/issues/265

PS: It's my first time messing with code on github. Sorry, if I didn't follow protocol correctly.