### PR TITLE
Use jellyfin's DisplayTitle for audio and subtitle streams

### DIFF
--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -557,23 +557,6 @@ class PlayUtils(object):
 
         return path
 
-    def get_commercial_codec_name(self, codec, profile):
-        NAMES = {
-            'ac3': 'Dolby Digital',
-            'eac3': 'Dolby Digital+',
-            'truehd': 'Dolby TrueHD',
-            'dts': 'DTS'
-        }
-
-        if profile == 'DTS-HD MA':
-            return 'DTS-HD Master Audio'
-        if profile == 'DTS-HD HRA':
-            return 'DTS-HD High Resolution Audio'
-        if codec in NAMES:
-            return NAMES[codec]
-
-        return codec.upper()
-
     def get_audio_subs(self, source, audio=None, subtitle=None):
 
         ''' For transcoding only
@@ -597,14 +580,7 @@ class PlayUtils(object):
 
             if stream_type == 'Audio':
 
-                profile = stream['Profile'] if 'Profile' in stream else None
-                codec = self.get_commercial_codec_name(stream['Codec'], profile)
-                channel = stream.get('ChannelLayout', "").capitalize()
-
-                if 'Language' in stream:
-                    track = "%s - %s %s" % (stream['Language'].capitalize(), codec, channel)
-                else:
-                    track = "%s %s" % (codec, channel)
+                track = stream['DisplayTitle']
 
                 audio_streams[track] = index
 
@@ -617,17 +593,7 @@ class PlayUtils(object):
                     if not avail_for_extraction and not allow_burned_subs:
                         continue
 
-                codec = self.get_commercial_codec_name(stream['Codec'], None)
-
-                if 'Language' in stream:
-                    track = "%s - %s" % (stream['Language'].capitalize(), codec)
-                else:
-                    track = "%s" % codec
-
-                if stream['IsDefault']:
-                    track = "%s - Default" % track
-                if stream['IsForced']:
-                    track = "%s - Forced" % track
+                track = stream['DisplayTitle']
 
                 subs_streams[track] = index
 


### PR DESCRIPTION
This makes the titles of audio and subtitle streams consistent with Jellyfin's web-ui. It's also more descriptive.

In addition, it partially works around this bug: https://github.com/jellyfin/jellyfin-kodi/issues/435
To fully fix this bug - that is allowing multiple streams with identical properties to show up in the list - I would suggest, replacing ordered dictionaries with something better suited. If you agree, I might look into that.