### PR TITLE
Store a version parameter in the database for migrations

### DIFF
--- a/jellyfin_kodi/database/jellyfin_db.py
+++ b/jellyfin_kodi/database/jellyfin_db.py
@@ -144,3 +144,15 @@ class JellyfinDatabase():
 
     def remove_media_by_parent_id(self, *args):
         self.cursor.execute(QU.delete_media_by_parent_id, args)
+
+    def get_version(self):
+        self.cursor.execute(QU.get_version)
+
+        return self.cursor.fetchone()
+
+    def add_version(self, *args):
+        '''
+        We only ever want one value here, so erase the existing contents first
+        '''
+        self.cursor.execute(QU.delete_version)
+        self.cursor.execute(QU.add_version, args)

--- a/jellyfin_kodi/entrypoint/service.py
+++ b/jellyfin_kodi/entrypoint/service.py
@@ -427,4 +427,3 @@ class Service(xbmc.Monitor):
             self.monitor.listener.stop()
 
         LOG.info("---<<<[ %s ]", client.get_addon_name())
-

--- a/jellyfin_kodi/entrypoint/service.py
+++ b/jellyfin_kodi/entrypoint/service.py
@@ -427,3 +427,4 @@ class Service(xbmc.Monitor):
             self.monitor.listener.stop()
 
         LOG.info("---<<<[ %s ]", client.get_addon_name())
+


### PR DESCRIPTION
Allows us to easily check against the database to verify if any migrations need to happen without doing any time intensive processing against it's contents.