### PR TITLE
Fix impossibility of choosing the first subtitle

### DIFF
--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -633,8 +633,8 @@ class PlayUtils(object):
             selection = list(['No subtitles']) + list(map(get_track_title, subs_streams))
             resp = dialog("select", translate(33014), selection) - 1
 
-            if resp:
-                index = subs_streams[resp] if resp > -1 else source.get('DefaultSubtitleStreamIndex')
+            if resp > -1:
+                index = subs_streams[resp]
 
                 if index is not None:
 


### PR DESCRIPTION
The usual combination of a zero-based index and a lazy if...

Also, there is no reason to use the default subtitles after asking users which subtitles they want.