### PR TITLE
fix: create release pr workflow

### DIFF
--- a/.github/releasing.md
+++ b/.github/releasing.md
@@ -1,0 +1,12 @@
+# Releasing a new Version via GitHub Actions
+
+0. (optional) label the PRs you want to include in this release (if you want to group them in the GH release based on topics). \
+   Supported labels can be found in the Release Drafter [config-file](https://github.com/jellyfin/jellyfin-meta-plugins/blob/master/.github/release-drafter.yml) (currently inherited from `jellyfin/jellyfin-meta-plugins`)
+1. ensure you have merged the PRs you want to include in the release and that the so far drafted GitHub release has captured them
+2. Create a `release-prep` PR by manually triggering the 'Create Prepare-Release PR' Workflow from the Actions tab on GitHub
+3. check the newly created `Prepare for release vx.y.z` PR if updated the `release.yaml` properly (update it manually if need be)
+4. merge the `Prepare for release vx.y.z` and let the Actions triggered by doing that finis (should just be a couple of seconds)
+5. FINALLY, trigger the `Publish Jellyfin-Kodi` manually from the Actions tab on GitHub.
+    1. this will release the up to that point drafted GitHub Release and tag the default branch accordingly
+    2. this will package and deploy `Jellyfin-Kodi` in the new version to the deployment server and trigger the 'kodirepo' script on it
+6. Done, assuming everything ran successfully, you have now successfully published a new version! :tada:

--- a/.github/workflows/create-prepare-release-pr.yaml
+++ b/.github/workflows/create-prepare-release-pr.yaml
@@ -1,4 +1,4 @@
-name: Create Release PR
+name: Create Prepare-Release PR
 
 on:
   workflow_dispatch:
@@ -25,9 +25,12 @@ jobs:
           cat << EOF >> cl.md
           ${{ steps.draft.outputs.body }}
           EOF
+          sed -i cl.md -e 's/^*/-/'
           TAG="${{ steps.draft.outputs.tag_name }}"
           echo "VERSION=${TAG#v}" >> $GITHUB_ENV
-          echo "CHANGELOG=`cat cl.md | grep '*'`" >> $GITHUB_ENV
+          echo "CHANGELOG<<EOF" >> $GITHUB_ENV
+          cat cl.md | grep '^-' >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
           rm cl.md
 
       - name: Checkout repository

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -57,7 +57,6 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST  }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_KEY }}
-          envs: JELLYFIN_VERSION
           script_stop: true
           script: |
             python3 /usr/local/bin/kodirepo add /srv/repository/incoming/kodi/plugin.video.jellyfin+${{ matrix.py_version }}.zip --datadir /srv/repository/releases/client/kodi/${{ matrix.py_version }};


### PR DESCRIPTION
### Description

This PR aims to fix the 'Create Prepare-Release PR' workflow when there are multiple changelog lines (how did I not test this earlier :man_facepalming:) and provide a readme explaining the release workflow with GitHub Actions.

### Changes

* attempt to fix CHANGELOG environment variable
* remove a unneeded env pass in publish workflow
* add release workflow readme

### Issues

* n/a