### PR TITLE
fix: prevent dual GitHub release publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - name: Update Draft
         uses: release-drafter/release-drafter@v5.15.0
+        if: ${{ matrix.py_version == 'py3' }}
         with:
           publish: true
         env:


### PR DESCRIPTION
well not CI change that needs at least one or 2 fixes after it ran the first time :expressionless: 