### PR TITLE
Fix external sub conflict

### DIFF
--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -513,7 +513,7 @@ class PlayUtils(object):
                 LOG.info("[ subtitles/%s ] %s", index, url)
 
                 if 'Language' in stream:
-                    filename = "Stream.%s.%s" % (stream['Language'], stream['Codec'])
+                    filename = "%s.%s.%s" % (source['Id'], stream['Language'], stream['Codec'])
 
                     try:
                         subs.append(self.download_external_subs(url, filename))

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -426,7 +426,9 @@ class Player(xbmc.Player):
                 dirs, files = xbmcvfs.listdir(path)
 
                 for file in files:
-                    xbmcvfs.delete(os.path.join(path, file))
+                    # Only delete the cached files for the previous play session
+                    if item['Id'] in file:
+                        xbmcvfs.delete(os.path.join(path, file))
 
             result = item['Server'].jellyfin.get_item(item['Id']) or {}
 


### PR DESCRIPTION
Fixes #541.  Removes the ability for a race condition by naming the downloaded sub files after the item ID instead of all sharing the same name.