### PR TITLE
Add av1,vp9 support #545

### DIFF
--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -297,7 +297,7 @@ class PlayUtils(object):
         return int(xbmc.getInfoLabel('System.ScreenWidth')), int(xbmc.getInfoLabel('System.ScreenHeight'))
 
     def get_directplay_video_codec(self):
-        codecs = ['h264', 'hevc', 'h265', 'mpeg4', 'mpeg2video', 'vc1']
+        codecs = ['h264', 'hevc', 'h265', 'mpeg4', 'vp9', 'av1', 'mpeg2video', 'vc1']
 
         if settings('transcode_h265.bool'):
             codecs.remove('hevc')
@@ -309,10 +309,16 @@ class PlayUtils(object):
         if settings('transcode_vc1.bool'):
             codecs.remove('vc1')
 
+        if settings('transcode_vp9.bool'):
+            codecs.remove('vp9')
+
+        if settings('transcode_av1.bool'):
+            codecs.remove('av1')
+            
         return ','.join(codecs)
 
     def get_transcoding_video_codec(self):
-        codecs = ['h264', 'hevc', 'h265', 'mpeg4', 'mpeg2video', 'vc1']
+        codecs = ['h264', 'hevc', 'h265', 'mpeg4', 'vp9', 'av1','mpeg2video', 'vc1']
 
         if settings('transcode_h265.bool'):
             codecs.remove('hevc')
@@ -326,6 +332,12 @@ class PlayUtils(object):
 
         if settings('transcode_vc1.bool'):
             codecs.remove('vc1')
+
+        if settings('transcode_vp9.bool'):
+            codecs.remove('vp9')
+
+        if settings('transcode_av1.bool'):
+            codecs.remove('av1')
 
         return ','.join(codecs)
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -48,6 +48,8 @@
 	    <setting label="30522" id="transcode_h265" type="bool" default="false" visible="true" />
 	    <setting label="30523" id="transcode_mpeg2" type="bool" default="false" visible="true" />
 	    <setting label="30524" id="transcode_vc1" type="bool" default="false" visible="true" />
+		<setting label="30525" id="transcode_av1" type="bool" default="false" visible="true" />
+		<setting label="30526" id="transcode_vp9" type="bool" default="false" visible="true" />
 	    <setting label="30161" id="videoPreferredCodec" type="select" values="H264/AVC|H265/HEVC" visible="eq(-2,false)" default="H264/AVC" />
 	    <setting label="30162" id="audioPreferredCodec" type="select" values="AAC|AC3|MP3|Opus|FLAC|Vorbis" visible="true" default="AAC" />
 	    <setting label="30163" id="audioBitrate" type="enum" values="96|128|160|192|256|320|384" visible="true" default="4" />

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -48,8 +48,8 @@
 	    <setting label="30522" id="transcode_h265" type="bool" default="false" visible="true" />
 	    <setting label="30523" id="transcode_mpeg2" type="bool" default="false" visible="true" />
 	    <setting label="30524" id="transcode_vc1" type="bool" default="false" visible="true" />
-		<setting label="30525" id="transcode_av1" type="bool" default="false" visible="true" />
-		<setting label="30526" id="transcode_vp9" type="bool" default="false" visible="true" />
+		  <setting label="30525" id="transcode_av1" type="bool" default="false" visible="true" />
+		  <setting label="30526" id="transcode_vp9" type="bool" default="false" visible="true" />
 	    <setting label="30161" id="videoPreferredCodec" type="select" values="H264/AVC|H265/HEVC" visible="eq(-2,false)" default="H264/AVC" />
 	    <setting label="30162" id="audioPreferredCodec" type="select" values="AAC|AC3|MP3|Opus|FLAC|Vorbis" visible="true" default="AAC" />
 	    <setting label="30163" id="audioBitrate" type="enum" values="96|128|160|192|256|320|384" visible="true" default="4" />


### PR DESCRIPTION
Please replace all strings.po in "plugin.video.jellyfin\resources\language\" like resource.language.en_us, since I don't know how to replace them all quickly:
`
956 msgctxt "#30524"
957 msgid "Transcode VC-1"
958 msgstr "Transcode VC-1"
959
960 +msgctxt "#30525"
+msgid "Transcode AV1"
+msgstr "Transcode AV1"

+msgctxt "#30526"
+msgid "Transcode VP9"
+msgstr "Transcode VP9"

+msgctxt "#30523"
+msgid "Transcode MPEG2"
+msgstr "Transcode MPEG2"

+msgctxt "#30165"
+msgid "Allow burned subtitles"
+msgstr "Allow burned subtitles"
`