### PR TITLE
Fixes #557 - Add missing "PlaySessionId"

### DIFF
--- a/jellyfin_kodi/jellyfin/api.py
+++ b/jellyfin_kodi/jellyfin/api.py
@@ -356,9 +356,10 @@ class API(object):
             'LiveStreamId': live_id
         })
 
-    def close_transcode(self, device_id):
+    def close_transcode(self, device_id, play_id):
         return self._delete("Videos/ActiveEncodings", params={
-            'DeviceId': device_id
+            'DeviceId': device_id,
+            'PlaySessionId': play_id
         })
 
     def get_default_headers(self):

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -418,7 +418,7 @@ class Player(xbmc.Player):
             elif item['PlayMethod'] == 'Transcode':
 
                 LOG.info("<[ transcode/%s ]", item['Id'])
-                item['Server'].jellyfin.close_transcode(item['DeviceId'])
+                item['Server'].jellyfin.close_transcode(item['DeviceId'], item['PlaySessionId'])
 
             path = xbmc.translatePath("special://profile/addon_data/plugin.video.jellyfin/temp/")
 


### PR DESCRIPTION
Looks like only the first commit was needed, so here's the slimmed down version of the fix in #557.

jellyfin_kodi/{jellyfin/api,player}.py: Add missing "PlaySessionId" argument to close_transcode().

Without this argument, server always returns 400.