### PR TITLE
Allow browsing to a show from the info menu

### DIFF
--- a/jellyfin_kodi/entrypoint/default.py
+++ b/jellyfin_kodi/entrypoint/default.py
@@ -144,6 +144,10 @@ class Events(object):
             backup()
         elif mode == 'restartservice':
             window('jellyfin.restart.bool', True)
+        elif mode == None and not params:
+            # Used when selecting "Browse" from a context menu, see #548
+            item_id = base_url.strip('/').split('/')[-1]
+            browse('', item_id, None, server, api_client)
         else:
             listing()
 


### PR DESCRIPTION
Kinda/sorta fixes #548.  It's not _right_, but I can't get it working the preferred way way.  This method queries the server for data, which is obviously slower than looking in the local database.  But I'm running into Kodi limitations and a large chunk of refactoring to get local content to display properly.