### PR TITLE
Don't fail fast on the py test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         py_version: ['2.7', '3.9']
     steps:


### PR DESCRIPTION
Even if Py2 tests fail, I'd like to know if Py3 passes or the other way around.