### PR TITLE
Don't store CriticRating in the userrating db field

### DIFF
--- a/jellyfin_kodi/jellyfin/api.py
+++ b/jellyfin_kodi/jellyfin/api.py
@@ -26,7 +26,7 @@ def info():
         "Path,Genres,SortName,Studios,Writer,Taglines,LocalTrailerCount,"
         "OfficialRating,CumulativeRunTimeTicks,ItemCounts,"
         "Metascore,AirTime,DateCreated,People,Overview,"
-        "CriticRating,CriticRatingSummary,Etag,ShortOverview,ProductionLocations,"
+        "Etag,ShortOverview,ProductionLocations,"
         "Tags,ProviderIds,ParentId,RemoteTrailers,SpecialEpisodeNumbers,"
         "MediaSources,VoteCount,RecursiveItemCount,PrimaryImageAspectRatio"
     )

--- a/jellyfin_kodi/objects/actions.py
+++ b/jellyfin_kodi/objects/actions.py
@@ -419,7 +419,6 @@ class Actions(object):
                 'imdbnumber': obj['UniqueId'],
                 'lastplayed': obj['DatePlayed'],
                 'duration': obj['Runtime'],
-                'userrating': obj['CriticRating']
             })
 
         elif obj['Type'] == 'MusicVideo':

--- a/jellyfin_kodi/objects/kodi/queries.py
+++ b/jellyfin_kodi/objects/kodi/queries.py
@@ -285,13 +285,13 @@ VALUES          (?, ?, ?, ?)
 """
 add_movie = """
 INSERT INTO     movie(idMovie, idFile, c00, c01, c02, c03, c04, c05, c06, c07,
-                c09, c10, c11, c12, c14, c15, c16, c18, c19, c21, userrating, premiered)
+                c09, c10, c11, c12, c14, c15, c16, c18, c19, c21, premiered)
 VALUES          (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
 add_movie_obj = ["{MovieId}", "{FileId}", "{Title}", "{Plot}", "{ShortPlot}", "{Tagline}",
                  "{Votes}", "{RatingId}", "{Writers}", "{Year}", "{Unique}", "{SortTitle}",
                  "{Runtime}", "{Mpaa}", "{Genre}", "{Directors}", "{Title}", "{Studio}",
-                 "{Trailer}", "{Country}", "{CriticRating}", "{Year}"]
+                 "{Trailer}", "{Country}", "{Year}"]
 add_rating = """
 INSERT INTO     rating(rating_id, media_id, media_type, rating_type, rating, votes)
 VALUES          (?, ?, ?, ?, ?, ?)
@@ -399,13 +399,13 @@ update_movie = """
 UPDATE      movie
 SET         c00 = ?, c01 = ?, c02 = ?, c03 = ?, c04 = ?, c05 = ?, c06 = ?,
             c07 = ?, c09 = ?, c10 = ?, c11 = ?, c12 = ?, c14 = ?, c15 = ?,
-            c16 = ?, c18 = ?, c19 = ?, c21 = ?, userrating = ?, premiered = ?
+            c16 = ?, c18 = ?, c19 = ?, c21 = ?, premiered = ?
 WHERE       idMovie = ?
 """
 update_movie_obj = ["{Title}", "{Plot}", "{ShortPlot}", "{Tagline}", "{Votes}", "{RatingId}",
                     "{Writers}", "{Year}", "{Unique}", "{SortTitle}", "{Runtime}",
                     "{Mpaa}", "{Genre}", "{Directors}", "{Title}", "{Studio}", "{Trailer}",
-                    "{Country}", "{CriticRating}", "{Year}", "{MovieId}"]
+                    "{Country}", "{Year}", "{MovieId}"]
 update_rating = """
 UPDATE      rating
 SET         media_id = ?, media_type = ?, rating_type = ?, rating = ?, votes = ?


### PR DESCRIPTION
Fixes #569

Doesn't look like Jellyfin has a concept of user ratings, which is probably why the critic rating field was used instead.