### PR TITLE
ci: fix dependabot labels

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,12 +7,10 @@ updates:
     labels:
       - ci
       - github-actions
-      - dependencies
   - package-ecosystem: pip
     directory: /
     schedule:
       interval: weekly
     labels:
-      - ci
       - pip
       - dependencies


### PR DESCRIPTION
### Description

The current labels cause duplicate entries in the release drafter changelog so this change the applied labels on new dependabot PRs to stop this.

### Change(s)

* remove dependencies label for bump prs of github actions
* remove ci label for bump PRs of pip (requirements-dev.txt) prs

### Issue(s)

* n/a

### To fix the current draft

* remove the labels retroactively on the dependabot PRs before this fix
* run/re-run the Release Drafter Action once