### PR TITLE
Add acces token in unsecured endpoints

### DIFF
--- a/jellyfin_kodi/connect.py
+++ b/jellyfin_kodi/connect.py
@@ -149,7 +149,8 @@ class Connect(object):
 
         if 'PrimaryImageTag' in self.user:
             server_address = client.auth.get_server_info(client.auth.server_id)['address']
-            window('JellyfinUserImage', api.API(self.user, server_address).get_user_artwork(self.user['Id']))
+            api_key = client.auth.jellyfin_token()
+            window('JellyfinUserImage', api.API(self.user, server_address, api_key).get_user_artwork(self.user['Id']))
 
     def select_servers(self, state=None):
 

--- a/jellyfin_kodi/entrypoint/default.py
+++ b/jellyfin_kodi/entrypoint/default.py
@@ -529,7 +529,7 @@ def get_fanart(item_id, path, server_id=None, api_client=None):
         xbmcvfs.mkdirs(directory)
         item = api_client.get_item(item_id)
         obj = objects.map(item, 'Artwork')
-        backdrops = api.API(item).get_all_artwork(obj)
+        backdrops = api.API(item, None, api_client.config.data['auth.token']).get_all_artwork(obj)
         tags = obj['BackdropTags']
 
         for index, backdrop in enumerate(backdrops):

--- a/jellyfin_kodi/helper/api.py
+++ b/jellyfin_kodi/helper/api.py
@@ -13,13 +13,14 @@ LOG = LazyLogger(__name__)
 
 
 class API(object):
-    def __init__(self, item, server=None):
+    def __init__(self, item, server=None, api_key=None):
 
         ''' Get item information in special cases.
             server is the server address, provide if your functions requires it.
         '''
         self.item = item
         self.server = server
+        self.api_key = api_key
 
     def get_playcount(self, played, playcount):
 
@@ -303,6 +304,8 @@ class API(object):
         for index, tag in enumerate(tags):
 
             artwork = "%s/Items/%s/Images/Backdrop/%s?Format=original&Tag=%s%s" % (self.server, item_id, index, tag, (query or ""))
+            if self.api_key is not None:
+                artwork += "&api_key=%s" % self.api_key
             backdrops.append(artwork)
 
         return backdrops
@@ -321,5 +324,8 @@ class API(object):
 
         if query is not None:
             url += query or ""
+
+        if self.api_key is not None:
+            url += "&api_key=%s" % self.api_key
 
         return url

--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -212,7 +212,7 @@ class PlayUtils(object):
         self.info['SubtitleStreamIndex'] = self.info.get('SubtitleStreamIndex') or source.get('DefaultSubtitleStreamIndex')
         self.item['PlaybackInfo'].update(self.info)
 
-        API = api.API(self.item, self.info['ServerAddress'])
+        API = api.API(self.item, self.info['ServerAddress'], self.api_client.config.data['auth.token'])
         window('jellyfinfilename', value=API.get_file_path(source.get('Path')))
 
     def live_stream(self, source):
@@ -264,7 +264,7 @@ class PlayUtils(object):
 
     def direct_play(self, source):
 
-        API = api.API(self.item, self.info['ServerAddress'])
+        API = api.API(self.item, self.info['ServerAddress'], self.api_client.config.data['auth.token'])
         self.info['Method'] = "DirectPlay"
         self.info['Path'] = API.get_file_path(source.get('Path'))
 

--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -655,7 +655,7 @@ class UpdateWorker(threading.Thread):
                         music.song(item)
 
                     if self.notify:
-                        self.notify_output.put((item['Type'], api.API(item).get_naming()))
+                        self.notify_output.put((item['Type'], api.API(item, None, self.server.auth.jellyfin_token()).get_naming()))
                 except LibraryException as error:
                     if error.status == 'StopCalled':
                         break

--- a/jellyfin_kodi/monitor.py
+++ b/jellyfin_kodi/monitor.py
@@ -196,7 +196,7 @@ class Monitor(xbmc.Monitor):
         for index, user in enumerate(session[0]['AdditionalUsers']):
 
             info = server.jellyfin.get_user(user['UserId'])
-            image = api.API(info, server.config.data['auth.server']).get_user_artwork(user['UserId'])
+            image = api.API(info, server.config.data['auth.server'], server.config.data['auth.token']).get_user_artwork(user['UserId'])
             window('JellyfinAdditionalUserImage.%s' % index, image)
             window('JellyfinAdditionalUserPosition.%s' % user['UserId'], str(index))
 

--- a/jellyfin_kodi/objects/actions.py
+++ b/jellyfin_kodi/objects/actions.py
@@ -226,7 +226,7 @@ class Actions(object):
     def set_listitem(self, item, listitem, db_id=None, seektime=None, intro=False):
 
         objects = Objects()
-        API = api.API(item, self.server)
+        API = api.API(item, self.server, self.api_client.config.data["auth.token"])
 
         if item['Type'] in ('MusicArtist', 'MusicAlbum', 'Audio'):
 
@@ -284,7 +284,7 @@ class Actions(object):
 
         ''' Set listitem for video content. That also include streams.
         '''
-        API = api.API(item, self.server)
+        API = api.API(item, self.server, self.api_client.config.data["auth.token"])
         is_video = obj['MediaType'] in ('Video', 'Audio')  # audiobook
 
         obj['Genres'] = " / ".join(obj['Genres'] or [])
@@ -476,7 +476,7 @@ class Actions(object):
 
         ''' Set listitem for channel content.
         '''
-        API = api.API(item, self.server)
+        API = api.API(item, self.server, self.api_client.config.data["auth.token"])
 
         obj['Title'] = "%s - %s" % (obj['Title'], obj['ProgramName'])
         obj['Runtime'] = round(float((obj['Runtime'] or 0) / 10000000.0), 6)
@@ -519,7 +519,7 @@ class Actions(object):
         listitem.setContentLookup(False)
 
     def listitem_music(self, obj, listitem, item):
-        API = api.API(item, self.server)
+        API = api.API(item, self.server, self.api_client.config.data["auth.token"])
 
         obj['Runtime'] = round(float((obj['Runtime'] or 0) / 10000000.0), 6)
         obj['PlayCount'] = API.get_playcount(obj['Played'], obj['PlayCount']) or 0
@@ -576,7 +576,7 @@ class Actions(object):
         listitem.setContentLookup(False)
 
     def listitem_photo(self, obj, listitem, item):
-        API = api.API(item, self.server)
+        API = api.API(item, self.server, self.api_client.config.data["auth.token"])
 
         obj['Overview'] = API.get_overview(obj['Overview'])
         obj['FileDate'] = "%s.%s.%s" % tuple(reversed(obj['FileDate'].split('T')[0].split('-')))

--- a/jellyfin_kodi/objects/movies.py
+++ b/jellyfin_kodi/objects/movies.py
@@ -47,7 +47,7 @@ class Movies(KodiDb):
             If item exists, entry will be updated.
         '''
         server_address = self.server.auth.get_server_info(self.server.auth.server_id)['address']
-        API = api.API(item, server_address)
+        API = api.API(item, server_address, self.server.auth.jellyfin_token())
         obj = self.objects.map(item, 'Movie')
         update = True
 
@@ -219,7 +219,7 @@ class Movies(KodiDb):
             Process removals from boxset.
         '''
         server_address = self.server.auth.get_server_info(self.server.auth.server_id)['address']
-        API = api.API(item, server_address)
+        API = api.API(item, server_address, self.server.auth.jellyfin_token())
         obj = self.objects.map(item, 'Boxset')
 
         obj['Overview'] = API.get_overview(obj['Overview'])
@@ -297,7 +297,7 @@ class Movies(KodiDb):
             Poster with progress bar
         '''
         server_address = self.server.auth.get_server_info(self.server.auth.server_id)['address']
-        API = api.API(item, server_address)
+        API = api.API(item, server_address, self.server.auth.jellyfin_token())
         obj = self.objects.map(item, 'MovieUserData')
 
         try:

--- a/jellyfin_kodi/objects/music.py
+++ b/jellyfin_kodi/objects/music.py
@@ -44,7 +44,7 @@ class Music(KodiDb):
             If item exists, entry will be updated.
         '''
         server_address = self.server.auth.get_server_info(self.server.auth.server_id)['address']
-        API = api.API(item, server_address)
+        API = api.API(item, server_address, self.server.auth.jellyfin_token())
         obj = self.objects.map(item, 'Artist')
         update = True
 
@@ -118,7 +118,7 @@ class Music(KodiDb):
         ''' Update object to kodi.
         '''
         server_address = self.server.auth.get_server_info(self.server.auth.server_id)['address']
-        API = api.API(item, server_address)
+        API = api.API(item, server_address, self.server.auth.jellyfin_token())
         obj = self.objects.map(item, 'Album')
         update = True
 
@@ -242,7 +242,7 @@ class Music(KodiDb):
         ''' Update object to kodi.
         '''
         server_address = self.server.auth.get_server_info(self.server.auth.server_id)['address']
-        API = api.API(item, server_address)
+        API = api.API(item, server_address, self.server.auth.jellyfin_token())
         obj = self.objects.map(item, 'Song')
         update = True
 

--- a/jellyfin_kodi/objects/musicvideos.py
+++ b/jellyfin_kodi/objects/musicvideos.py
@@ -51,7 +51,7 @@ class MusicVideos(KodiDb):
             from the sortname attribute.
         '''
         server_address = self.server.auth.get_server_info(self.server.auth.server_id)['address']
-        API = api.API(item, server_address)
+        API = api.API(item, server_address, self.server.auth.jellyfin_token())
         obj = self.objects.map(item, 'MusicVideo')
         update = True
 
@@ -195,7 +195,7 @@ class MusicVideos(KodiDb):
             Poster with progress bar
         '''
         server_address = self.server.auth.get_server_info(self.server.auth.server_id)['address']
-        API = api.API(item, server_address)
+        API = api.API(item, server_address, self.server.auth.jellyfin_token())
         obj = self.objects.map(item, 'MusicVideoUserData')
 
         try:

--- a/jellyfin_kodi/objects/tvshows.py
+++ b/jellyfin_kodi/objects/tvshows.py
@@ -55,7 +55,7 @@ class TVShows(KodiDb):
             Apply series pooling.
         '''
         server_address = self.server.auth.get_server_info(self.server.auth.server_id)['address']
-        API = api.API(item, server_address)
+        API = api.API(item, server_address, self.server.auth.jellyfin_token())
         obj = self.objects.map(item, 'Series')
         update = True
 
@@ -219,7 +219,7 @@ class TVShows(KodiDb):
             If the show is empty, try to remove it.
         '''
         server_address = self.server.auth.get_server_info(self.server.auth.server_id)['address']
-        API = api.API(item, server_address)
+        API = api.API(item, server_address, self.server.auth.jellyfin_token())
         obj = self.objects.map(item, 'Season')
 
         obj['ShowId'] = show_id
@@ -255,7 +255,7 @@ class TVShows(KodiDb):
             This is only required for plugin/episode.
         '''
         server_address = self.server.auth.get_server_info(self.server.auth.server_id)['address']
-        API = api.API(item, server_address)
+        API = api.API(item, server_address, self.server.auth.jellyfin_token())
         obj = self.objects.map(item, 'Episode')
         update = True
 
@@ -464,7 +464,7 @@ class TVShows(KodiDb):
             Create additional entry for widgets. This is only required for plugin/episode.
         '''
         server_address = self.server.auth.get_server_info(self.server.auth.server_id)['address']
-        API = api.API(item, server_address)
+        API = api.API(item, server_address, self.server.auth.jellyfin_token())
         obj = self.objects.map(item, 'EpisodeUserData')
 
         try:

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -261,7 +261,7 @@ class Player(xbmc.Player):
 
                 break
         server_address = item['Server'].auth.get_server_info(item['Server'].auth.server_id)['address']
-        API = api.API(next_item, server_address)
+        API = api.API(next_item, server_address, item['Server'].auth.jellyfin_token())
         data = objects.map(next_item, "UpNext")
         artwork = API.get_all_artwork(objects.map(next_item, 'ArtworkParent'), True)
         data['art'] = {

--- a/jellyfin_kodi/views.py
+++ b/jellyfin_kodi/views.py
@@ -858,7 +858,8 @@ class Views(object):
 
                 if library['Id'] == view_id and 'Primary' in library.get('ImageTags', {}):
                     server_address = self.server.auth.get_server_info(self.server.auth.server_id)['address']
-                    artwork = api.API(None, server_address).get_artwork(view_id, 'Primary')
+                    api_key = self.server.auth.jellyfin_tokne()
+                    artwork = api.API(None, server_address, api_key).get_artwork(view_id, 'Primary')
                     window('%s.artwork' % prop, artwork)
 
                     break

--- a/jellyfin_kodi/views.py
+++ b/jellyfin_kodi/views.py
@@ -858,7 +858,7 @@ class Views(object):
 
                 if library['Id'] == view_id and 'Primary' in library.get('ImageTags', {}):
                     server_address = self.server.auth.get_server_info(self.server.auth.server_id)['address']
-                    api_key = self.server.auth.jellyfin_tokne()
+                    api_key = self.server.auth.jellyfin_token()
                     artwork = api.API(None, server_address, api_key).get_artwork(view_id, 'Primary')
                     window('%s.artwork' % prop, artwork)
 


### PR DESCRIPTION
I am implementing jellyfin http proxy for monitoring and strict control of the access to the service.  My main goal is to block everything other than login page if you don't have access token in form of header/cookie/query since jellyfin seems to have open endpoints for the metadata (and other security issues with non-admin users). 
This pull requests just adds query parameter `api_key` to the artwork/backdrops endpoints. 