### PR TITLE
Remove option: Developer mode

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -104,7 +104,6 @@
 		<setting label="33195" id="enableAddon" type="bool" default="true" />
 		<setting label="33180" type="action" action="RunPlugin(plugin://plugin.video.jellyfin?mode=restartservice)" option="close" />
 		<setting label="30529" id="startupDelay" type="number" default="0" option="int" />
-		<setting label="Developer mode" id="devMode" type="bool" default="false" />
 
 		<setting type="sep" />
 		<setting label="33104" type="lsep"/>


### PR DESCRIPTION
This option is unused and has no reason to be around.