### PR TITLE
Fix syncing when Premiere attribute is an int

### DIFF
--- a/jellyfin_kodi/objects/movies.py
+++ b/jellyfin_kodi/objects/movies.py
@@ -95,7 +95,7 @@ class Movies(KodiDb):
         obj['Audio'] = API.audio_streams(obj['Audio'] or [])
         obj['Streams'] = API.media_streams(obj['Video'], obj['Audio'], obj['Subtitles'])
         if obj['Premiere'] is not None:
-            obj['Premiere'] = obj['Premiere'].split('T')[0]
+            obj['Premiere'] = str(obj['Premiere']).split('T')[0]
 
         self.get_path_filename(obj)
         self.trailer(obj)


### PR DESCRIPTION
Due to a recent change in `movies.py`, I'm getting the following error when trying to sync movies where the "Premiere" field is set to a year only (as an `int` rather than a full date string):
```
INFO <general>: JELLYFIN.jellyfin_kodi.database -> ERROR::jellyfin_kodi\database\__init__.py:166 type: <class 'AttributeError'> value: 'int' object has no attribute 'split'
```

By converting it to a string, it no longer causes the sync error. 