### PR TITLE
Fix music video db update

### DIFF
--- a/jellyfin_kodi/objects/kodi/kodi.py
+++ b/jellyfin_kodi/objects/kodi/kodi.py
@@ -147,8 +147,8 @@ class Kodi(object):
                 bulk_updates.setdefault(sql, []).append((person_id,) + args)
 
             elif person['Type'] == 'Artist':
-                sql = QU.update_link.replace("{LinkType}", 'actor_link')
-                bulk_updates.setdefault(sql, []).append((person_id,) + args)
+                sql = QU.insert_link_if_not_exists.replace("{LinkType}", 'actor_link')
+                bulk_updates.setdefault(sql, []).append((person_id,) + args + (person_id,) + args)
 
             add_thumbnail(person_id, person, person['Type'])
 

--- a/jellyfin_kodi/objects/kodi/queries.py
+++ b/jellyfin_kodi/objects/kodi/queries.py
@@ -395,6 +395,13 @@ update_link = """
 INSERT OR REPLACE INTO      {LinkType}(actor_id, media_id, media_type)
 VALUES                      (?, ?, ?)
 """
+# update_link does not work for actor_link as not all values from unique index are provided
+# Resulting in duplicates
+insert_link_if_not_exists = """
+INSERT INTO                 {LinkType}(actor_id, media_id, media_type)
+SELECT ?, ?, ? 
+WHERE NOT EXISTS(SELECT 1 FROM {LinkType} WHERE actor_id = ? AND media_id = ? AND media_type = ?)
+"""
 update_movie = """
 UPDATE      movie
 SET         c00 = ?, c01 = ?, c02 = ?, c03 = ?, c04 = ?, c05 = ?, c06 = ?,

--- a/jellyfin_kodi/objects/musicvideos.py
+++ b/jellyfin_kodi/objects/musicvideos.py
@@ -86,8 +86,6 @@ class MusicVideos(KodiDb):
             obj['Year'] = int(str(obj['Year'])[:4])
 
         obj['Path'] = API.get_file_path(obj['Path'])
-        obj['LibraryId'] = self.library['Id']
-        obj['LibraryName'] = self.library['Name']
         obj['Genres'] = obj['Genres'] or []
         obj['ArtistItems'] = obj['ArtistItems'] or []
         obj['Studios'] = [API.validate_studio(studio) for studio in (obj['Studios'] or [])]


### PR DESCRIPTION
- Artist link to a music video was inserted using "insert or update", passing values that did not constitute an unique key, resulting in duplicate links (and appearing like duplicate videos in db, at least with my kodi settings).
- In musicvideos.py, obj['LibraryId'] and obj['LibraryName'] was incorrectly set, when they were correctly set a few lines before.
I removed the problematic lines of code (see diff).
This fixes automatic updates of the music video library, new videos were not added before this change.