### PR TITLE
Handle musicvideo artists as actors

### DIFF
--- a/jellyfin_kodi/objects/kodi/kodi.py
+++ b/jellyfin_kodi/objects/kodi/kodi.py
@@ -146,10 +146,6 @@ class Kodi(object):
                 sql = QU.update_link.replace("{LinkType}", 'writer_link')
                 bulk_updates.setdefault(sql, []).append((person_id,) + args)
 
-            elif person['Type'] == 'Artist':
-                sql = QU.update_link.replace("{LinkType}", 'actor_link')
-                bulk_updates.setdefault(sql, []).append((person_id,) + args)
-
             add_thumbnail(person_id, person, person['Type'])
 
         for sql, parameters in bulk_updates.items():

--- a/jellyfin_kodi/objects/musicvideos.py
+++ b/jellyfin_kodi/objects/musicvideos.py
@@ -113,9 +113,11 @@ class MusicVideos(KodiDb):
             obj['Premiere'] = str(obj['Premiere']).split('.')[0].replace('T', " ")
 
         for artist in obj['ArtistItems']:
-            artist['Type'] = "Artist"
+            artist['Type'] = "Actor"
 
-        obj['People'] = obj['People'] or [] + obj['ArtistItems']
+        obj['People'] = (obj['People'] or []) + obj['ArtistItems']
+        for person in obj['People']:
+            person['Role'] = person.get('Role', '')
         obj['People'] = API.get_people_artwork(obj['People'])
 
         if obj['Index'] is None and obj['SortTitle'] is not None:


### PR DESCRIPTION
This is intended as an alternative to #742
It currently fixes the new duplicate on each sync (caused by falling back to null in some fields).
It does however currently duplicate actor entries if they are edited server side.

I haven't quite decided whether I should have it delete the old entries before adding the new ones.