### PR TITLE
Fix music multidisc indexing

### DIFF
--- a/jellyfin_kodi/objects/music.py
+++ b/jellyfin_kodi/objects/music.py
@@ -291,8 +291,7 @@ class Music(KodiDb):
         if obj['DatePlayed']:
             obj['DatePlayed'] = Local(obj['DatePlayed']).split('.')[0].replace('T', " ")
 
-        if obj['Disc'] != 1:
-            obj['Index'] = obj['Disc'] * 2 ** 16 + obj['Index']
+        obj['Index'] = obj['Disc'] * 2 ** 16 + obj['Index']
 
         if update:
             self.song_update(obj)


### PR DESCRIPTION
Kodi uses internally a right-shift operation to codify in a single integer disc number and track number. This is taken into account in this addon but, incorrectly, it is done for discnumber > 1 only, while Kodi uses it for tracks in all discs.

Fix this by directly codifying the track and disc number for all discs.

This patch is based on investigation by user @neightwulf in github.

Fixes #732