### PR TITLE
use thought when calling to vfs for esoteric media

### DIFF
--- a/jellyfin_kodi/objects/movies.py
+++ b/jellyfin_kodi/objects/movies.py
@@ -189,13 +189,13 @@ class Movies(KodiDb):
             obj['Path'] = obj['Path'].replace(obj['Filename'], "")
 
             '''check dvd directories and point it to ./VIDEO_TS/VIDEO_TS.IFO'''
-            if validate_dvd_dir(obj['Path'] + obj['Filename']):
+            if ('Container' not in obj or ('Container' in obj and obj['Container'] == 'dvd')) and validate_dvd_dir(obj['Path'] + obj['Filename']):
                 obj['Path'] = obj['Path'] + obj['Filename'] + '/VIDEO_TS/'
                 obj['Filename'] = 'VIDEO_TS.IFO'
                 LOG.debug("DVD directory %s", obj['Path'])
 
             '''check bluray directories and point it to ./BDMV/index.bdmv'''
-            if validate_bluray_dir(obj['Path'] + obj['Filename']):
+            if ('Container' not in obj or ('Container' in obj and obj['Container'] == 'bluray')) and validate_bluray_dir(obj['Path'] + obj['Filename']):
                 obj['Path'] = obj['Path'] + obj['Filename'] + '/BDMV/'
                 obj['Filename'] = 'index.bdmv'
                 LOG.debug("Bluray directory %s", obj['Path'])

--- a/jellyfin_kodi/objects/tvshows.py
+++ b/jellyfin_kodi/objects/tvshows.py
@@ -412,13 +412,13 @@ class TVShows(KodiDb):
             obj['Path'] = obj['Path'].replace(obj['Filename'], "")
 
             '''check dvd directories and point it to ./VIDEO_TS/VIDEO_TS.IFO'''
-            if validate_dvd_dir(obj['Path'] + obj['Filename']):
+            if ('Container' not in obj or ('Container' in obj and obj['Container'] == 'dvd')) and validate_dvd_dir(obj['Path'] + obj['Filename']):
                 obj['Path'] = obj['Path'] + obj['Filename'] + '/VIDEO_TS/'
                 obj['Filename'] = 'VIDEO_TS.IFO'
                 LOG.debug("DVD directory %s", obj['Path'])
 
             '''check bluray directories and point it to ./BDMV/index.bdmv'''
-            if validate_bluray_dir(obj['Path'] + obj['Filename']):
+            if ('Container' not in obj or ('Container' in obj and obj['Container'] == 'bluray')) and validate_bluray_dir(obj['Path'] + obj['Filename']):
                 obj['Path'] = obj['Path'] + obj['Filename'] + '/BDMV/'
                 obj['Filename'] = 'index.bdmv'
                 LOG.debug("Bluray directory %s", obj['Path'])


### PR DESCRIPTION
so I barely know python, but saw that there were massive stalls for populating the database with a very tiny media library. There's still some massive slowdown on series retrieval, but the episodes load in in about a second now from minutes previously. This results in a 7x performance improvement (time reduction) for library import overall, with about a 90x reduction on per-episode import.