### PR TITLE
Fix syncing of mixed TV libraries

### DIFF
--- a/jellyfin_kodi/helper/utils.py
+++ b/jellyfin_kodi/helper/utils.py
@@ -548,10 +548,10 @@ def find_library(server, item):
     from ..database import get_sync
 
     sync = get_sync()
-
+    whitelist = [x.replace('Mixed:', "") for x in sync['Whitelist']]
     ancestors = server.jellyfin.get_ancestors(item['Id'])
     for ancestor in ancestors:
-        if ancestor['Id'] in sync['Whitelist']:
+        if ancestor['Id'] in whitelist:
             return ancestor
 
     LOG.error('No ancestor found, not syncing item with ID: {}'.format(item['Id']))


### PR DESCRIPTION
If the library was mixed, it can not be found since the it's ID has prefix "Mixed:".