### PR TITLE
Make sure pytest actually fails CI on windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,9 +63,6 @@ jobs:
       - name: Generate coverage report
         run: |
           coverage xml
-
-      - name: Print coverage report
-        run: |
           coverage report
 
       - name: Upload coverage

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,14 +56,16 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --output-file=flake8.output
           cat flake8.output
 
-      - name: Test with pytest
-        run: |
-          pytest
-
-      - name: Generate Coverage
+      - name: Run tests and generate coverage
         run: |
           coverage run
+
+      - name: Generate coverage report
+        run: |
           coverage xml
+
+      - name: Print coverage report
+        run: |
           coverage report
 
       - name: Upload coverage

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,11 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --output-file=flake8.output
           cat flake8.output
 
-      - name: Test with Coverage
+      - name: Test with pytest
+        run: |
+          pytest
+
+      - name: Generate Coverage
         run: |
           coverage run
           coverage xml


### PR DESCRIPTION
For whatever reason, the error code from `coverage run` is not surfacing to the Windows runner, and therefore the CI is passing despite several unit tests failing.

Using `pytest` directly does surface the proper error code and halt CI if any tests fail, so that has been added as a step.

`coverage run` is still executed, after `pytest`, to generate the necessary information needed for `coverage xml` and `coverage report`. Because `pytest` runs first, the false-negative tests in `coverage run` will never be encountered.

This fails as expected:
![image](https://github.com/jellyfin/jellyfin-kodi/assets/17054780/3308179c-08c0-4041-a3ea-cac3ca022d04)


Closes #777 