### PR TITLE
Fix convert_to_local tests on Windows

### DIFF
--- a/jellyfin_kodi/helper/utils.py
+++ b/jellyfin_kodi/helper/utils.py
@@ -474,14 +474,14 @@ def split_list(itemlist, size):
     return [itemlist[i:i + size] for i in range(0, len(itemlist), size)]
 
 
-def convert_to_local(date):
+def convert_to_local(date, timezone=tz.tzlocal()):
 
     ''' Convert the local datetime to local.
     '''
     try:
         date = parser.parse(date) if isinstance(date, string_types) else date
         date = date.replace(tzinfo=tz.tzutc())
-        date = date.astimezone(tz.tzlocal())
+        date = date.astimezone(timezone)
         # Bad metadata defaults to date 1-1-1.  Catch it and don't throw errors
         if date.year < 1900:
             # FIXME(py2): strftime don't like dates below 1900

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,9 @@ futures >= 2.2; python_version < '3.0'
 PyYAML >= 5.4; python_version < '3.0'
 PyYAML >= 6.0; python_version >= '3.6'
 
+backports.zoneinfo; python_version < "3.9" and python_version >= '3.0'
+tzdata; platform_system == "Windows" and python_version >= '3.0'
+
 Kodistubs ~= 18.0; python_version < '3.0'
 Kodistubs ~= 20.0; python_version >= '3.6'
 


### PR DESCRIPTION
I've been unable to find any tzset equivalent for Windows.

The closest I got was this stackoverflow answer from 2011, but it is 10 years outdated, code no longer runs (errors on the `msvcrt.ctime`), and suggests recompiling Python with specific preprocessor flags is required.
https://stackoverflow.com/a/6972586/1035647