### PR TITLE
Fix uncaught exception in Player.report_playback()

### DIFF
--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -326,7 +326,11 @@ class Player(xbmc.Player):
         if not report:
 
             previous = item['CurrentPosition']
-            item['CurrentPosition'] = int(self.getTime())
+
+            try:
+                item['CurrentPosition'] = int(self.getTime())
+            except Exception:  # at this point we should be playing and if not then bail out
+                return
 
             if int(item['CurrentPosition']) == 1:
                 return

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -329,7 +329,9 @@ class Player(xbmc.Player):
 
             try:
                 item['CurrentPosition'] = int(self.getTime())
-            except Exception:  # at this point we should be playing and if not then bail out
+            except Exception as e:
+                # getTime() raises RuntimeError if nothing is playing
+                LOG.debug("Failed to get playback position: %s", e)
                 return
 
             if int(item['CurrentPosition']) == 1:


### PR DESCRIPTION
I see regular exceptions thrown in `Player.report_playback()`, as below:

```
2023-11-19 21:32:20.858 T:1220    error <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'RuntimeError'>
                                                   Error Contents: Kodi is not playing any media file
                                                   Traceback (most recent call last):
                                                     File "/storage/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/player.py", line 308, in onPlayBackSeek
                                                       self.report_playback()
                                                     File "/storage/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/player.py", line 352, in report_playback
                                                       item['CurrentPosition'] = int(self.getTime())
                                                                                     ^^^^^^^^^^^^^^
                                                   RuntimeError: Kodi is not playing any media file
                                                   -->End of Python script error report<--
```

This is not entirely unsurprising, since this method is called from numerous places, and in [at least one case](https://github.com/jellyfin/jellyfin-kodi/blob/e95e8d6a88d706f096a5a15b3d53b1fe1214fb2c/jellyfin_kodi/monitor.py#L251) is called with a delay, meaning that media playback may have completed before the method is called.