### PR TITLE
Use xbmcvfs functions to read and write filesystem files

### DIFF
--- a/jellyfin_kodi/helper/xmls.py
+++ b/jellyfin_kodi/helper/xmls.py
@@ -117,13 +117,18 @@ def verify_kodi_defaults():
 
         if xbmcvfs.exists(file_name):
             try:
-                tree = etree.parse(file_name)
+                with xbmcvfs.File(file_name) as f:
+                    b = f.read()
+                    tree = etree.ElementTree(etree.fromstring(b))
             except etree.ParseError:
                 LOG.error("Unable to parse `{}`".format(file_name))
                 LOG.exception("We ensured the file was OK above, something is wrong!")
+                tree = None
 
-            tree.getroot().set('order', str(17 + index))
-            tree.write(file_name)
+            if tree is not None:
+                tree.getroot().set('order', str(17 + index))
+                with xbmcvfs.File(file_name, 'w') as f:
+                    f.write(etree.tostring(tree.getroot()))
 
     playlist_path = translate_path("special://profile/playlists/video")
 


### PR DESCRIPTION
At the moment, this plugin is not working on Apple TV devices.
This is because on tvOS the virtual filesystem used by Kodi hides a more complex system where in reality any XML file of Kodi is compressed in the NSUSerDefaults dictionary.
In others words, that mean that on tvOS a Kodi plugin cannot directly read or write an XML file, instead, the add-on needs to use the `xbmcvfs` functions in order to let Kodi performs the translation between the virtual filesystem and the "real" filesystem that is OS/device dependent.

This PR modify the plugin so that the XML reads and writes use `xbmcvfs` functions.
This way, this PR allow this add-on to works on tvOS devices.

For more details, see discussion here: https://forum.kodi.tv/showthread.php?tid=374294&pid=3177147#pid3177147

Tested on macOS and Apple TV with Kodi 20.