### PR TITLE
Add setting to force transcode Dobly Vision

### DIFF
--- a/jellyfin_kodi/helper/api.py
+++ b/jellyfin_kodi/helper/api.py
@@ -73,7 +73,20 @@ class API(object):
 
         for track in tracks:
 
+            if "DvProfile" in track:
+                track['hdrtype'] = "dolbyvision"
+			
+            elif track['VideoRangeType'] in ["HDR10", "HDR10Plus"]:
+                track['hdrtype'] = "hdr10"
+
+            elif "HLG" in track['VideoRangeType']:
+                track['hdrtype'] = "hlg"
+			
+            elif track['VideoRangeType'] in ["SDR", "Unknown"]:
+                track['hdrtype'] = ""
+
             track.update({
+                'hdrtype': track.get('hdrtype', "").lower(),
                 'codec': track.get('Codec', "").lower(),
                 'profile': track.get('Profile', "").lower(),
                 'height': track.get('Height'),

--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -328,6 +328,10 @@ class PlayUtils(object):
     def get_transcoding_video_codec(self):
         codecs = ['h264', 'hevc', 'h265', 'mpeg4', 'mpeg2video', 'vc1']
 
+        if settings('transcode_dolbyvision.bool'):
+            codecs.remove('hevc')
+            codecs.remove('h265')
+
         if settings('transcode_h265.bool'):
             codecs.remove('hevc')
             codecs.remove('h265')

--- a/jellyfin_kodi/objects/actions.py
+++ b/jellyfin_kodi/objects/actions.py
@@ -455,6 +455,7 @@ class Actions(object):
 
             for track in obj['Streams']['video']:
                 listitem.addStreamInfo('video', {
+                    'hdrtype': track['hdrtype'],
                     'duration': obj['Runtime'],
                     'aspect': track['aspect'],
                     'codec': track['codec'],

--- a/jellyfin_kodi/objects/actions.py
+++ b/jellyfin_kodi/objects/actions.py
@@ -65,8 +65,8 @@ class Actions(object):
         '''
         listitem = xbmcgui.ListItem()
         LOG.info("[ play/%s ] %s", item['Id'], item['Name'])
-
-        transcode = transcode or settings('playFromTranscode.bool')
+        
+        transcode = transcode or settings('playFromTranscode.bool') or self.check_transcodeDolbyVision(item)
         play = playutils.PlayUtils(item, transcode, self.server_id, self.server, self.api_client)
         source = play.select_source(play.get_sources())
         play.set_external_subs(source, listitem)
@@ -77,6 +77,19 @@ class Actions(object):
 
         if len(sys.argv) > 1:
             xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, self.stack[0][1])
+
+    def check_transcodeDolbyVision(self, item):
+
+        API = api.API(item, self.server)
+        objects = Objects()
+        obj = objects.map(item, 'BrowseVideo')
+        obj['Video'] = API.video_streams(obj['Video'] or [], obj['Container'])
+
+        if settings('transcode_dolbyvision.bool') and obj['Video'][0]['hdrtype'] == 'dolbyvision':
+            
+            return True
+
+        return False
 
     def set_playlist(self, item, listitem, db_id=None, transcode=False):
 

--- a/jellyfin_kodi/objects/kodi/queries.py
+++ b/jellyfin_kodi/objects/kodi/queries.py
@@ -258,10 +258,10 @@ add_bookmark_obj = ["{FileId}", "{PlayCount}", "{DatePlayed}", "{Resume}", "{Run
 add_streams_obj = ["{FileId}", "{Streams}", "{Runtime}"]
 add_stream_video = """
 INSERT INTO     streamdetails(idFile, iStreamType, strVideoCodec, fVideoAspect, iVideoWidth,
-                iVideoHeight, iVideoDuration, strStereoMode)
-VALUES          (?, ?, ?, ?, ?, ?, ?, ?)
+                iVideoHeight, iVideoDuration, strStereoMode, strHdrType)
+VALUES          (?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
-add_stream_video_obj = ["{FileId}", 0, "{codec}", "{aspect}", "{width}", "{height}", "{Runtime}", "{3d}"]
+add_stream_video_obj = ["{FileId}", 0, "{codec}", "{aspect}", "{width}", "{height}", "{Runtime}", "{3d}", "{hdrtype}"]
 add_stream_audio = """
 INSERT INTO     streamdetails(idFile, iStreamType, strAudioCodec, iAudioChannels, strAudioLanguage)
 VALUES          (?, ?, ?, ?, ?)

--- a/resources/language/resource.language.ar/strings.po
+++ b/resources/language/resource.language.ar/strings.po
@@ -864,6 +864,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "تحويل H265 / HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33201"
 msgid "Max artwork resolution"
 msgstr "أقصى دقة للعمل الفني"

--- a/resources/language/resource.language.be/strings.po
+++ b/resources/language/resource.language.be/strings.po
@@ -1007,6 +1007,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Перакадзіраваць H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#29999"
 msgid "Jellyfin for Kodi"
 msgstr "Jellyfin для Kodi"

--- a/resources/language/resource.language.bg/strings.po
+++ b/resources/language/resource.language.bg/strings.po
@@ -1013,3 +1013,7 @@ msgstr "Включи дистанционно управление"
 msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Декодира H265/HEVC RExt"
+
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"

--- a/resources/language/resource.language.ca/strings.po
+++ b/resources/language/resource.language.ca/strings.po
@@ -608,6 +608,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transcodificar H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33128"
 msgid "Failed to retrieve latest content updates. No content updates will be applied until Kodi is restarted. If this issue persists, please report on the Jellyfin for Kodi forums, with your Kodi log."
 msgstr ""

--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -1001,6 +1001,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Překódovat H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Povolit vzdálené ovládání"

--- a/resources/language/resource.language.da/strings.po
+++ b/resources/language/resource.language.da/strings.po
@@ -259,6 +259,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Omkod H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33201"
 msgid "Max artwork resolution"
 msgstr "Maksimal opløsning af kunstværk"

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -1099,6 +1099,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transkodiere H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Fernsteuerung aktivieren"

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -791,6 +791,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Διακωδικοποίηση H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33109"
 msgid "Plugin"
 msgstr "Πρόσθετο"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -996,3 +996,7 @@ msgstr "Max artwork resolution"
 msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transcode H265/HEVC RExt"
+
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -1004,3 +1004,7 @@ msgstr "Max stream bitrate"
 msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transcode H265/HEVC RExt"
+
+msgctxt "#33203"
+msgid "Force transcode of DolbyVision"
+msgstr "Force transcode of DolbyVision"

--- a/resources/language/resource.language.eo/strings.po
+++ b/resources/language/resource.language.eo/strings.po
@@ -989,3 +989,7 @@ msgstr "Ebligi plibonigitan artaĵon (t.e. Cover Art)"
 msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transkodigo H265/HEVC RExt"
+
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"

--- a/resources/language/resource.language.es_419/strings.po
+++ b/resources/language/resource.language.es_419/strings.po
@@ -1018,6 +1018,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transcodificar H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Habilitar control remoto"

--- a/resources/language/resource.language.es_AR/strings.po
+++ b/resources/language/resource.language.es_AR/strings.po
@@ -1014,6 +1014,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transcodificar H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Habilitar control remoto"

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -1022,6 +1022,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transcodificar H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Habilitar control remoto"

--- a/resources/language/resource.language.et/strings.po
+++ b/resources/language/resource.language.et/strings.po
@@ -989,6 +989,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transkoodi H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Luba kaugjuhtimine"

--- a/resources/language/resource.language.fi/strings.po
+++ b/resources/language/resource.language.fi/strings.po
@@ -1003,6 +1003,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transkoodaa H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Ota etäohjaus käyttöön"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -1083,6 +1083,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transcoder le H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Activer le contrôle à distance"

--- a/resources/language/resource.language.hr/strings.po
+++ b/resources/language/resource.language.hr/strings.po
@@ -494,6 +494,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transkodiranje H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33160"
 msgid "To avoid errors, please update Jellyfin for Kodi to version: "
 msgstr "Da biste izbjegli greške, ažurirajte Jellyfin for Kodi na verziju: "

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -1012,6 +1012,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "H265/HEVC RExt átkódolás"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Távirányító engedélyezése"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -1081,6 +1081,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transcodifica H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Abilita controllo remoto"

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -942,6 +942,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "H265/HEVC RExtをトランスコード"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#30161"
 msgid "Preferred video codec"
 msgstr "優先する動画コーデック"

--- a/resources/language/resource.language.kk/strings.po
+++ b/resources/language/resource.language.kk/strings.po
@@ -1000,3 +1000,7 @@ msgstr "VP9 qaita kodtau"
 msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "H265/HEVC RExt qaita kodtau"
+
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -988,3 +988,7 @@ msgstr "외부 리모콘 켜다"
 msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "코덱변화 H265/HEVC RExt"
+
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"

--- a/resources/language/resource.language.lv_lv/strings.po
+++ b/resources/language/resource.language.lv_lv/strings.po
@@ -941,6 +941,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Pārkodēt H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33138"
 msgid "You can update your library manually rather than rely on the server plugin Kodi Sync Queue. Launch the add-on and update libraries (or per library). To remove content, you'll need to repair the library."
 msgstr ""

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -1012,6 +1012,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Omkod H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Aktiver fjernkontroll"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -1066,6 +1066,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transcoderen H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Externe besturing toelaten"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -1060,6 +1060,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transkodowanie H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Włącz sterowanie zdalne"

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -1015,6 +1015,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transcodificação H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Habilitar o controle remoto"

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -1012,3 +1012,7 @@ msgstr "Habilitar controle remoto"
 msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transcodificação H265/HEVC RExt"
+
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"

--- a/resources/language/resource.language.ro/strings.po
+++ b/resources/language/resource.language.ro/strings.po
@@ -1016,6 +1016,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transcodare H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Activează controlul de la distanță"

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -1018,6 +1018,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Перекодирование H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Включить удалённый контроль"

--- a/resources/language/resource.language.sk_sk/strings.po
+++ b/resources/language/resource.language.sk_sk/strings.po
@@ -1014,6 +1014,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Prekódovať H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Povoliť vzdialené ovládanie"

--- a/resources/language/resource.language.sl/strings.po
+++ b/resources/language/resource.language.sl/strings.po
@@ -998,6 +998,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transkodiraj H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33153"
 msgid "Your Jellyfin theme media has been synced to Kodi"
 msgstr "Mediji tvoje teme so bili sinhronizirani s Kodi"

--- a/resources/language/resource.language.sr_rs/strings.po
+++ b/resources/language/resource.language.sr_rs/strings.po
@@ -1011,6 +1011,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Транскодирај H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "омогућити даљинско управљање"

--- a/resources/language/resource.language.sv/strings.po
+++ b/resources/language/resource.language.sv/strings.po
@@ -880,6 +880,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Omkoda H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33186"
 msgid "The Kodi Sync Queue speeds up the start up sync. Other syncs are triggered by server events."
 msgstr ""

--- a/resources/language/resource.language.ta/strings.po
+++ b/resources/language/resource.language.ta/strings.po
@@ -1005,3 +1005,7 @@ msgstr "டிரான்ஸ்கோட் VP9"
 msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "டிரான்ஸ்கோட் H265/HEVC RExt"
+
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"

--- a/resources/language/resource.language.tr_tr/strings.po
+++ b/resources/language/resource.language.tr_tr/strings.po
@@ -1006,6 +1006,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Kod Dönüştüme H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "Uzaktan Erişimi etkinleştir"

--- a/resources/language/resource.language.uk/strings.po
+++ b/resources/language/resource.language.uk/strings.po
@@ -566,6 +566,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Перекодувати H265/HEVC RExt"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33179"
 msgid "Force transcode"
 msgstr "Примусове перекодування"

--- a/resources/language/resource.language.zh_Hant/strings.po
+++ b/resources/language/resource.language.zh_Hant/strings.po
@@ -35,6 +35,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "輸入備份資料夾名稱"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33128"
 msgid "Failed to retrieve latest content updates. No content updates will be applied until Kodi is restarted. If this issue persists, please report on the Jellyfin for Kodi forums, with your Kodi log."
 msgstr ""

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -959,6 +959,10 @@ msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "转码 H265/HEVC Rext"
 
+msgctxt "#33203"
+msgid "Transcode DolbyVision"
+msgstr "Transcode DolbyVision"
+
 msgctxt "#33125"
 msgid "Enable remote control"
 msgstr "启用远程控制"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -47,6 +47,7 @@
 
 		<setting type="sep" />
 		<setting label="33115" type="lsep" />
+		<setting label="33203" id="transcode_dolbyvision" type="bool" default="false" visible="true" />
 		<setting label="30537" id="transcodeHi10P" type="bool" default="false" visible="true" />
 		<setting label="30522" id="transcode_h265" type="bool" default="false" visible="true" />
 		<setting label="33202" id="transcode_h265_rext" type="bool" default="false" visible="eq(-1,false)" />


### PR DESCRIPTION
Added setting to allow force transcode of Dolby Vision files.

This PR includes the hdr metadata fix.

On Firestick 4k Max, it is useful to be able to force a transcode with tone mapping for Dolby Vision files, otherwise certain profiles / combination of profiles just show a blank screen. I've had to force a transcode to h264 to achieve this. 