### PR TITLE
Fix websocket automatic reconnection

### DIFF
--- a/jellyfin_kodi/jellyfin/ws_client.py
+++ b/jellyfin_kodi/jellyfin/ws_client.py
@@ -35,7 +35,6 @@ class WSClient(threading.Thread):
 
         self.client = client
         threading.Thread.__init__(self)
-        self.retry_count = 0
 
     def send(self, message, data=""):
 
@@ -62,23 +61,18 @@ class WSClient(threading.Thread):
 
         while not self.stop:
 
-            time.sleep(self.retry_count * 5)
-            self.wsc.run_forever(ping_interval=10)
+            self.wsc.run_forever(ping_interval=10, reconnect=10)
 
             if not self.stop and monitor.waitForAbort(5):
                 break
-
-            # Wait a maximum of 60 seconds before retrying connection
-            if self.retry_count < 12:
-                self.retry_count += 1
-
-        LOG.info("---<[ websocket ]")
 
     def on_error(self, ws, error):
         LOG.error(error)
 
     def on_open(self, ws):
-        LOG.info("--->[ websocket ]")
+        LOG.info("--->[ websocket opened ]")
+        # Avoid a timing issue where the capabilities are not correctly registered
+        time.sleep(1)
         if settings('remoteControl.bool'):
             self.client.jellyfin.post_capabilities({
                 'PlayableMediaTypes': "Audio,Video",
@@ -99,8 +93,6 @@ class WSClient(threading.Thread):
                 "PlayableMediaTypes": "Audio, Video",
                 "SupportsMediaControl": False
             })
-        # Reinitialize the retry counter after successful connection
-        self.retry_count = 0
 
     def on_message(self, ws, message):
 

--- a/jellyfin_kodi/jellyfin/ws_client.py
+++ b/jellyfin_kodi/jellyfin/ws_client.py
@@ -72,7 +72,7 @@ class WSClient(threading.Thread):
     def on_open(self, ws):
         LOG.info("--->[ websocket opened ]")
         # Avoid a timing issue where the capabilities are not correctly registered
-        time.sleep(1)
+        time.sleep(5)
         if settings('remoteControl.bool'):
             self.client.jellyfin.post_capabilities({
                 'PlayableMediaTypes': "Audio,Video",

--- a/release.yaml
+++ b/release.yaml
@@ -34,4 +34,4 @@ dependencies:
     - addon: 'script.module.addon.signals'
       version: '0.0.5+matrix.1'
     - addon: 'script.module.websocket'
-      version: '0.58.0+matrix.1'
+      version: '1.6.4'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pytest >= 4.6.11
 coverage >= 5.2
 flake8 >= 3.8
 flake8-import-order >= 0.18
-websocket-client >= 0.57.0
+websocket-client >= 1.6.4
 
 types-requests >= 2.31
 types-PyYAML >= 6.0


### PR DESCRIPTION
Changes the reconnection approach to use the reconnect function of the websocket-client library. The current approach throws an error but does not reconnect.

After reconnection a small delay was needed before the session capabilities are registered otherwise the client will not appear as user controllable.

Resolves #797