### PR TITLE
Pin CI versions and clean up after py2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,15 +10,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        py_version: [ 'py3' ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.9
 
@@ -27,13 +24,13 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pyyaml
 
-      - name: Create ${{ matrix.py_version }} addon.xml
-        run: python build.py --version ${{ matrix.py_version }}
+      - name: Build addon
+        run: python build.py
 
       - name: Publish Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           retention-days: 14
-          name: ${{ matrix.py_version }}-build-artifact
+          name: py3-build-artifact
           path: |
             *.zip

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -16,26 +16,23 @@ jobs:
     if: ${{ github.repository == 'jellyfin/jellyfin-kodi' }}
     strategy:
       fail-fast: false
-      matrix:
-        language: [ 'python' ]
-        version: ['3.9']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v3.24.0
         with:
-          languages: ${{ matrix.language }}
+          languages: 'python'
           queries: +security-and-quality
 
-      - name: Set up Python ${{ matrix.version }}
-        uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5.0.0
         with:
-          python-version: ${{ matrix.version }}
+          python-version: 3.9
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v3.24.0
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v3.24.0

--- a/.github/workflows/create-prepare-release-pr.yaml
+++ b/.github/workflows/create-prepare-release-pr.yaml
@@ -21,7 +21,7 @@ jobs:
           yq-version: v4.9.1
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: Parse Changelog
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,23 +6,19 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        py_version: [ 'py3' ]
     steps:
       - name: Update Draft
         uses: release-drafter/release-drafter@v6.0.0
-        if: ${{ matrix.py_version == 'py3' }}
         with:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.9
 
@@ -31,19 +27,19 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pyyaml
 
-      - name: Create ${{ matrix.py_version }} addon.xml
-        run: python build.py --version ${{ matrix.py_version }}
+      - name: Build addon
+        run: python build.py
 
       - name: Publish Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           retention-days: 14
-          name: ${{ matrix.py_version }}-build-artifact
+          name: py3-build-artifact
           path: |
             *.zip
 
       - name: Upload to repo server
-        uses: burnett01/rsync-deployments@5.2
+        uses: burnett01/rsync-deployments@6.0.0
         with:
           switches: -vrptz
           path: '*.zip'
@@ -60,5 +56,5 @@ jobs:
           key: ${{ secrets.DEPLOY_KEY }}
           script_stop: true
           script: |
-            python3 /usr/local/bin/kodirepo add /srv/repository/incoming/kodi/plugin.video.jellyfin+${{ matrix.py_version }}.zip --datadir /srv/repository/releases/client/kodi/${{ matrix.py_version }};
-            rm /srv/repository/incoming/kodi/plugin.video.jellyfin+${{ matrix.py_version }}.zip;
+            python3 /usr/local/bin/kodirepo add /srv/repository/incoming/kodi/plugin.video.jellyfin+py3.zip --datadir /srv/repository/releases/client/kodi/py3;
+            rm /srv/repository/incoming/kodi/plugin.video.jellyfin+py3.zip;

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
 
       - name: Set up Python ${{ matrix.py_version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: ${{ matrix.py_version }}
 
@@ -56,7 +56,7 @@ jobs:
         if: ${{ matrix.py_version == '3.11' }}
 
       - name: Publish Test Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.3
         with:
           retention-days: 14
           name: ${{ matrix.py_version }}-test-results


### PR DESCRIPTION
📌 Pin CI dependency versions to fully qualified version numbers
🧹 Clean up CI after removing py2