### PR TITLE
Quick and dirty movie_view fix.

### DIFF
--- a/jellyfin_kodi/objects/kodi/movies.py
+++ b/jellyfin_kodi/objects/kodi/movies.py
@@ -48,6 +48,11 @@ class Movies(Kodi):
     def add(self, *args):
         self.cursor.execute(QU.add_movie, args)
 
+    def add_videoversion(self, *args):
+        self.cursor.execute(QU.check_video_version)
+        if self.cursor.fetchone()[0]==1 : 
+            self.cursor.execute(QU.add_video_version, args)
+
     def update(self, *args):
         self.cursor.execute(QU.update_movie, args)
 
@@ -55,6 +60,11 @@ class Movies(Kodi):
 
         self.cursor.execute(QU.delete_movie, (kodi_id,))
         self.cursor.execute(QU.delete_file, (file_id,))
+        self.cursor.execute(QU.check_video_version)
+        if self.cursor.fetchone()[0]==1 : 
+            self.cursor.execute(QU.delete_video_version, (file_id,))
+
+
 
     def get_rating_id(self, *args):
 

--- a/jellyfin_kodi/objects/kodi/queries.py
+++ b/jellyfin_kodi/objects/kodi/queries.py
@@ -315,6 +315,14 @@ INSERT INTO     sets(strSet, strOverview)
 VALUES          (?, ?)
 """
 add_set_obj = ["{Title}", "{Overview}"]
+add_video_version = """
+INSERT INTO     videoversion(idFile, idMedia, media_type, itemType, idType)
+VALUES          (?, ?, ?, ?, ?)
+"""
+check_video_version = """
+SELECT COUNT(name) FROM sqlite_master WHERE type='table' AND name='videoversion'
+"""
+add_video_version_obj = ["{FileId}","{MovieId}","movie","0",40400]
 add_musicvideo = """
 INSERT INTO     musicvideo(idMVideo, idFile, c00, c04, c05, c06, c07, c08, c09, c10,
                 c11, c12, premiered)
@@ -530,6 +538,10 @@ DELETE FROM     movie
 WHERE           idMovie = ?
 """
 delete_movie_obj = ["{KodiId}", "{FileId}"]
+delete_video_version = """
+DELETE FROM     videoversion
+WHERE           idFile = ?
+"""
 delete_set = """
 DELETE FROM     sets
 WHERE           idSet = ?

--- a/jellyfin_kodi/objects/movies.py
+++ b/jellyfin_kodi/objects/movies.py
@@ -143,6 +143,7 @@ class Movies(KodiDb):
         obj['FileId'] = self.add_file(*values(obj, QU.add_file_obj))
 
         self.add(*values(obj, QU.add_movie_obj))
+        self.add_videoversion(*values(obj, QU.add_video_version_obj))
         self.jellyfin_db.add_reference(*values(obj, QUEM.add_reference_movie_obj))
         LOG.debug("ADD movie [%s/%s/%s] %s: %s", obj['PathId'], obj['FileId'], obj['MovieId'], obj['Id'], obj['Title'])
 


### PR DESCRIPTION
Fixes movieview from Kodi 21 beta3 (videoversion implementation).
Compatible to versions w/o this feature (Kodi 20.4 tested).

Known issues:
Movies are added as "Standard Edition" no matter their real edition.