### PR TITLE
Add automatic database migration for Kodi Omega

### DIFF
--- a/jellyfin_kodi/objects/kodi/movies.py
+++ b/jellyfin_kodi/objects/kodi/movies.py
@@ -50,7 +50,7 @@ class Movies(Kodi):
 
     def add_videoversion(self, *args):
         self.cursor.execute(QU.check_video_version)
-        if self.cursor.fetchone()[0]==1 : 
+        if self.cursor.fetchone()[0] == 1:
             self.cursor.execute(QU.add_video_version, args)
 
     def update(self, *args):
@@ -61,10 +61,8 @@ class Movies(Kodi):
         self.cursor.execute(QU.delete_movie, (kodi_id,))
         self.cursor.execute(QU.delete_file, (file_id,))
         self.cursor.execute(QU.check_video_version)
-        if self.cursor.fetchone()[0]==1 : 
+        if self.cursor.fetchone()[0] == 1:
             self.cursor.execute(QU.delete_video_version, (file_id,))
-
-
 
     def get_rating_id(self, *args):
 
@@ -141,3 +139,35 @@ class Movies(Kodi):
 
     def delete_boxset(self, *args):
         self.cursor.execute(QU.delete_set, args)
+
+    def migrations(self):
+        '''
+        Used to trigger required database migrations for new versions
+        '''
+        self.cursor.execute(QU.get_version)
+        version_id = self.cursor.fetchone()[0]
+        changes = False
+
+        # Will run every time Kodi starts, but will be fast enough on
+        # subsequent runs to not be a meaningful delay
+        if version_id >= 131:
+            changes = self.omega_migration()
+
+        return changes
+
+    def omega_migration(self):
+        '''
+        Adds a video version for all existing movies
+        '''
+        LOG.info('Starting migration for Omega database changes')
+        # Tracks if this migration made any changes
+        changes = False
+        self.cursor.execute(QU.get_missing_versions)
+
+        # Sets all existing movies without a version to standard version
+        for entry in self.cursor.fetchall():
+            self.add_videoversion(entry[0], entry[1], "movie", "0", 40400)
+            changes = True
+
+        LOG.info('Omega database migration is complete')
+        return changes

--- a/jellyfin_kodi/objects/kodi/queries.py
+++ b/jellyfin_kodi/objects/kodi/queries.py
@@ -322,7 +322,7 @@ VALUES          (?, ?, ?, ?, ?)
 check_video_version = """
 SELECT COUNT(name) FROM sqlite_master WHERE type='table' AND name='videoversion'
 """
-add_video_version_obj = ["{FileId}","{MovieId}","movie","0",40400]
+add_video_version_obj = ["{FileId}", "{MovieId}", "movie", "0", 40400]
 add_musicvideo = """
 INSERT INTO     musicvideo(idMVideo, idFile, c00, c04, c05, c06, c07, c08, c09, c10,
                 c11, c12, premiered)
@@ -407,7 +407,7 @@ VALUES                      (?, ?, ?)
 # Resulting in duplicates
 insert_link_if_not_exists = """
 INSERT INTO                 {LinkType}(actor_id, media_id, media_type)
-SELECT ?, ?, ? 
+SELECT ?, ?, ?
 WHERE NOT EXISTS(SELECT 1 FROM {LinkType} WHERE actor_id = ? AND media_id = ? AND media_type = ?)
 """
 update_movie = """
@@ -580,4 +580,16 @@ DELETE FROM     art
 WHERE           media_id = ?
 AND             media_type = ?
 AND             type LIKE ?
+"""
+get_missing_versions = """
+SELECT          idFile,idMovie
+FROM            movie
+WHERE NOT EXISTS (
+    SELECT NULL FROM videoversion
+    WHERE       videoversion.idMedia = movie.idMovie
+)
+"""
+get_version = """
+SELECT      idVersion
+FROM        version
 """


### PR DESCRIPTION
Builds off of #831 to fix #808 

Detects if the video database version is 131 or higher (Kodi Omega beta3) to trigger a migration.  Sets all existing movies that are missing a version as a "standard" version like the original PR.

Also cleans up a few linter spacing complaints from the original PR that I missed during my review.