### PR TITLE
Check for KodiSyncQueue GetPluginSettings endpoint

### DIFF
--- a/jellyfin_kodi/helper/exceptions.py
+++ b/jellyfin_kodi/helper/exceptions.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, absolute_import, print_function, unicode_literals
 
+import warnings
+
 #################################################################################################
 
 
 class HTTPException(Exception):
     # Jellyfin HTTP exception
     def __init__(self, status, message):
+        warnings.warn(f'{self.__class__.__name__} will be deprecated.', DeprecationWarning, stacklevel=2)
         self.status = status
         self.message = message
 

--- a/jellyfin_kodi/jellyfin/api.py
+++ b/jellyfin_kodi/jellyfin/api.py
@@ -6,6 +6,7 @@ import json
 import requests
 from six import ensure_str
 
+from ..helper.exceptions import HTTPException
 from ..helper.utils import settings
 from ..helper import LazyLogger
 
@@ -267,6 +268,10 @@ class API(object):
         except requests.RequestException as e:
             LOG.warning("Error checking companion installed state: %s", e)
             if e.response.status_code == 404:
+                return False
+        except HTTPException as e:
+            LOG.warning("Error checking companion installed state: %s", e)
+            if e.status == 404:
                 return False
 
         return None

--- a/jellyfin_kodi/jellyfin/api.py
+++ b/jellyfin_kodi/jellyfin/api.py
@@ -254,37 +254,20 @@ class API(object):
             'ParentId': parent_id
         })
 
-    def get_plugins(self):
-        return self._get("Plugins")
-
-    def check_companion_installed(self):
+    def check_companion_enabled(self):
         """
+        True = Enabled
+        False = Not enabled
         None = Unknown
-        True = Installed, but possibly not loaded right now
-        False = Not installed, scheduled for uninstalling or disabled
         """
         try:
-            kodi_sync_queue = [
-                x
-                for x in self.get_plugins()
-                if x.get("Id") == "771e19d653854cafb35c28a0e865cf63"
-            ]
+            plugin_settings = self._get("Jellyfin.Plugin.KodiSyncQueue/GetPluginSettings") or {}
+            return plugin_settings.get('IsEnabled')
 
-            LOG.debug("KodiSyncQueue Plugins result: %s", kodi_sync_queue)
-
-            kodi_sync_queue_filtered = [
-                x
-                for x in kodi_sync_queue
-                if x.get("Status")
-                in ["Active", "Restart", "Malfunctioned", "NotSupported"]
-            ]
-
-            if kodi_sync_queue_filtered:
-                return True
-            else:
-                return False
         except requests.RequestException as e:
             LOG.warning("Error checking companion installed state: %s", e)
+            if e.response.status_code == 404:
+                return False
 
         return None
 

--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -353,7 +353,7 @@ class Library(threading.Thread):
                 'kodiCompanion.bool'
             ):
                 # None == Unknown
-                if self.server.jellyfin.check_companion_installed() is not False:
+                if self.server.jellyfin.check_companion_enabled() is not False:
 
                     if not self.fast_sync():
                         dialog("ok", "{jellyfin}", translate(33128))


### PR DESCRIPTION
To determine whether the plugin is enabled or not.

Does not check if any of the items to track settings are enabled, but assumes at least one of them are.

Fixes #861