### PR TITLE
[PEP 632] Update utils.py to use 'packaging' instead of deprecated 'distutils'

### DIFF
--- a/jellyfin_kodi/helper/utils.py
+++ b/jellyfin_kodi/helper/utils.py
@@ -10,7 +10,7 @@ import sys
 import re
 import unicodedata
 from uuid import uuid4
-from distutils.version import LooseVersion
+from packaging.version import parse
 
 from dateutil import tz, parser
 from six import text_type, string_types, iteritems, ensure_text, ensure_binary
@@ -112,8 +112,8 @@ def compare_version(a, b):
         1 a is larger
         0 equal
     '''
-    a = LooseVersion(a)
-    b = LooseVersion(b)
+    a = parse(a)
+    b = parse(b)
 
     if a < b:
         return -1


### PR DESCRIPTION
[PEP 632](https://peps.python.org/pep-0632/) deprecates the distutils module.

The module was marked as deprecated in Python 3.10 and 3.11, and was eventually removed in Python 3.12.

The PEP advises to replace the usage of `distutils.version` with `packaging.version`, the `LooseVersion` functionality being provided via its `parse` method.

This replacement advice is detailed in the PEP under '[Migration Advice](https://peps.python.org/pep-0632/#migration-advice)'