### PR TITLE
Clear playlist if clear flag is set (UpNext)

### DIFF
--- a/jellyfin_kodi/objects/actions.py
+++ b/jellyfin_kodi/objects/actions.py
@@ -166,13 +166,12 @@ class Actions(object):
         playlist = self.get_playlist(item)
         player = xbmc.Player()
 
-        # xbmc.executebuiltin("Playlist.Clear") # Clear playlist to remove the previous item from playlist position no.2
-
         if clear:
             if player.isPlaying():
                 player.stop()
 
             xbmc.executebuiltin('ActivateWindow(busydialognocancel)')
+            playlist.clear()
             index = 0
         else:
             index = max(playlist.getposition(), 0) + 1  # Can return -1
@@ -196,11 +195,12 @@ class Actions(object):
         playutils.set_properties(item, item['PlaybackInfo']['Method'], self.server_id)
 
         playlist.add(item['PlaybackInfo']['Path'], listitem, index)
-        index += 1
 
         if clear:
             xbmc.executebuiltin('Dialog.Close(busydialognocancel)')
-            player.play(playlist)
+            player.play(playlist, startpos=index)
+
+        index += 1
 
         server_address = item['PlaybackInfo']['ServerAddress']
         token = item['PlaybackInfo']['Token']


### PR DESCRIPTION
- Specifically continue to play the playlist at the insertion index
- Remove what seems to be a left over commented out section

Fixes issues with up next plugin where the popup would not show up after the first episode. Tested with Kodi v21 and jf4k 1.0.3 on Windows 11.

Fixes #717