### PR TITLE
Remove unused function compare_version

### DIFF
--- a/jellyfin_kodi/helper/__init__.py
+++ b/jellyfin_kodi/helper/__init__.py
@@ -16,7 +16,6 @@ from .utils import validate_bluray_dir
 from .utils import validate_dvd_dir
 from .utils import values
 from .utils import JSONRPC
-from .utils import compare_version
 from .utils import unzip
 from .utils import create_id
 from .utils import convert_to_local as Local

--- a/jellyfin_kodi/helper/utils.py
+++ b/jellyfin_kodi/helper/utils.py
@@ -10,7 +10,6 @@ import sys
 import re
 import unicodedata
 from uuid import uuid4
-from distutils.version import LooseVersion
 
 from dateutil import tz, parser
 from six import text_type, string_types, iteritems, ensure_text, ensure_binary
@@ -104,24 +103,6 @@ def settings(setting, value=None):
 
 def create_id():
     return uuid4()
-
-
-def compare_version(a, b):
-
-    ''' -1 a is smaller
-        1 a is larger
-        0 equal
-    '''
-    a = LooseVersion(a)
-    b = LooseVersion(b)
-
-    if a < b:
-        return -1
-
-    if a > b:
-        return 1
-
-    return 0
 
 
 def find(dict, item):


### PR DESCRIPTION
Closes #864
The usage of distutils here *may* be causing issues with py3.12 – not showing up in our tests tho.