### PR TITLE
Fix transcode settings visibility logic

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -47,14 +47,14 @@
 
 		<setting type="sep" />
 		<setting label="33115" type="lsep" />
+		<setting label="30161" id="videoPreferredCodec" type="select" values="H264/AVC|H265/HEVC|AV1" visible="true" default="H264/AVC" />
+		<setting label="30522" id="transcode_h265" type="bool" default="false" visible="!eq(-1,H265/HEVC)" />
+		<setting label="33202" id="transcode_h265_rext" type="bool" default="false" visible="eq(-1,false)|eq(-2,H265/HEVC)" subsetting="true" />
 		<setting label="30537" id="transcodeHi10P" type="bool" default="false" visible="true" />
-		<setting label="30522" id="transcode_h265" type="bool" default="false" visible="true" />
-		<setting label="33202" id="transcode_h265_rext" type="bool" default="false" visible="eq(-1,false)" />
 		<setting label="30523" id="transcode_mpeg2" type="bool" default="false" visible="true" />
 		<setting label="30524" id="transcode_vc1" type="bool" default="false" visible="true" />
 		<setting label="30525" id="transcode_vp9" type="bool" default="false" visible="true" />
-		<setting label="30526" id="transcode_av1" type="bool" default="false" visible="true" />
-		<setting label="30161" id="videoPreferredCodec" type="select" values="H264/AVC|H265/HEVC|AV1" visible="eq(-2,false)" default="H264/AVC" />
+		<setting label="30526" id="transcode_av1" type="bool" default="false" visible="!eq(-7,AV1)" />
 		<setting label="30162" id="audioPreferredCodec" type="select" values="AAC|AC3|MP3|Opus|FLAC|Vorbis" visible="true" default="AAC" />
 		<setting label="30163" id="audioBitrate" type="enum" values="96|128|160|192|256|320|384" visible="true" default="4" />
 		<setting label="30164" id="audioMaxChannels" type="slider" range="2,1,6" option="int" visible="true" default="6" />


### PR DESCRIPTION
Setting visivility should now be [as suggested](https://github.com/jellyfin/jellyfin-kodi/pull/892#discussion_r1712739243) by @Insprill in #892

The visibility logic has been broken for quite some time, due to the relative indexing used to refer to other options.