### PR TITLE
Remove native mode

### DIFF
--- a/jellyfin_kodi/helper/utils.py
+++ b/jellyfin_kodi/helper/utils.py
@@ -470,19 +470,8 @@ def has_attribute(obj, name):
 
 def set_addon_mode():
     """Setup playback mode. If native mode selected, check network credentials."""
-    value = dialog(
-        "yesno",
-        translate("playback_mode"),
-        translate(33035),
-        nolabel=translate("addon_mode"),
-        yeslabel=translate("native_mode"),
-    )
 
-    settings("useDirectPaths", value="1" if value else "0")
-
-    if value:
-        dialog("ok", "{jellyfin}", translate(33145))
-
+    settings("useDirectPaths", value="0")
     LOG.info("Add-on playback: %s", settings("useDirectPaths") == "0")
 
 


### PR DESCRIPTION
Server support is getting removed in Jellyfin 10.10
See jellyfin/jellyfin#12446 for the 10.10 removal in server and jellyfin/jellyfin-web#5098 for the 10.9 removal in web.
See also jellyfin/jellyfin#11654 for some discussion around the 10.9 removal.

I was certain there was more on the topic somewhere on GitHub (I feel like there's a discussion thread missing), but it is quite possible most if not all of it was discussed only in [chat (Matrix)](https://matrix.to/#/#jellyfinorg:matrix.org) and not properly documented on GitHub.

TODO:
- [ ] Test changes
      — not much that could go wrong here, I'm just skipping the dialog and setting the config value directly
- [ ] (Optional) Add warning dialog for existing installations using "native" mode
      — add a way to silence the warning if so
- [ ] (Optional) Remove all code related to native mode
      — probably best left for later