### PR TITLE
Add client native mode path replacement

### DIFF
--- a/jellyfin_kodi/helper/api.py
+++ b/jellyfin_kodi/helper/api.py
@@ -198,6 +198,14 @@ class API(object):
 
         return mpaa
 
+    def get_native_path_mappings(self):
+        return {
+            replace: replace_with
+            for i in range(1, 6)
+            if (replace := settings(f"directPathReplace{i}"))
+            and (replace_with := settings(f"directPathReplaceWith{i}"))
+        }
+
     def get_file_path(self, path=None):
 
         if path is None:
@@ -205,6 +213,11 @@ class API(object):
 
         if not path:
             return ""
+
+        native_mappings = self.get_native_path_mappings()
+        for replace, replace_with in native_mappings.items():
+            if path.startswith(replace):
+                path = path.replace(replace, replace_with, 1)
 
         if path.startswith("\\\\"):
             path = (

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -996,3 +996,43 @@ msgstr "Max artwork resolution"
 msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transcode H265/HEVC RExt"
+
+msgctxt "#33203"
+msgid "Native path replace 1"
+msgstr "Native path replace 1"
+
+msgctxt "#33204"
+msgid "Native path replace with 1"
+msgstr "Native path replace with 1"
+
+msgctxt "#33205"
+msgid "Native path replace 2"
+msgstr "Native path replace 2"
+
+msgctxt "#33206"
+msgid "Native path replace with 2"
+msgstr "Native path replace with 2"
+
+msgctxt "#33207"
+msgid "Native path replace 3"
+msgstr "Native path replace 3"
+
+msgctxt "#33208"
+msgid "Native path replace with 3"
+msgstr "Native path replace with 3"
+
+msgctxt "#33209"
+msgid "Native path replace 4"
+msgstr "Native path replace 4"
+
+msgctxt "#33210"
+msgid "Native path replace with 4"
+msgstr "Native path replace with 4"
+
+msgctxt "#33211"
+msgid "Native path replace 5"
+msgstr "Native path replace 5"
+
+msgctxt "#33212"
+msgid "Native path replace with 5"
+msgstr "Native path replace with 5"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -24,6 +24,16 @@
 		<setting label="30536" id="dbSyncScreensaver" type="bool" default="true" />
 		<setting label="33111" type="lsep" />
 		<setting label="30511" id="useDirectPaths" type="enum" lvalues="33036|33037" default="1" />
+		<setting label="33203" id="directPathReplace1" type="text" default="" />
+		<setting label="33204" id="directPathReplaceWith1" type="folder" source="" default="" />
+		<setting label="33205" id="directPathReplace2" type="text" default="" />
+		<setting label="33206" id="directPathReplaceWith2" type="folder" source="" default="" />
+		<setting label="33207" id="directPathReplace3" type="text" default="" />
+		<setting label="33208" id="directPathReplaceWith3" type="folder" source="" default="" />
+		<setting label="33209" id="directPathReplace4" type="text" default="" />
+		<setting label="33210" id="directPathReplaceWith4" type="folder" source="" default="" />
+		<setting label="33211" id="directPathReplace5" type="text" default="" />
+		<setting label="33212" id="directPathReplaceWith5" type="folder" source="" default="" />
 
 		<setting label="33175" type="lsep" />
 		<setting label="30515" id="limitIndex" type="slider" default="15" range="1, 1, 100" option="int" />


### PR DESCRIPTION
As an alternative to #925 this PR aims at bringing the removed functionality from jellyfin core into the addon itself.

Native mode is removed in 10.10 and was already phased out in jellyfin web in 10.9.

Closes #925 