### PR TITLE
Reimplement native mode to function client side

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,3 +4,5 @@
 be8333a80c2650c75444281a9b720da438b2b6d0
 # Change indentation of XML and JSON files
 7c0e986bd283c764cc16f0c756a03a04e4073ad0
+# Tool: black
+df4994bef23a1f7175d47ff4632084e153d6077f

--- a/jellyfin_kodi/entrypoint/default.py
+++ b/jellyfin_kodi/entrypoint/default.py
@@ -31,7 +31,7 @@ from ..helper.utils import (
     JsonDebugPrinter,
     translate_path,
     kodi_version,
-    path_replacements
+    path_replacements,
 )
 from ..jellyfin import Jellyfin
 

--- a/jellyfin_kodi/entrypoint/default.py
+++ b/jellyfin_kodi/entrypoint/default.py
@@ -285,7 +285,9 @@ def listing():
             )
 
     directory(translate(33194), "plugin://plugin.video.jellyfin/?mode=managelibs", True)
-    directory(translate(33203), "plugin://plugin.video.jellyfin/?mode=managepaths", True)
+    directory(
+        translate(33203), "plugin://plugin.video.jellyfin/?mode=managepaths", True
+    )
     directory(translate(33134), "plugin://plugin.video.jellyfin/?mode=addserver", False)
     directory(translate(33054), "plugin://plugin.video.jellyfin/?mode=adduser", False)
     directory(translate(5), "plugin://plugin.video.jellyfin/?mode=settings", False)

--- a/jellyfin_kodi/entrypoint/default.py
+++ b/jellyfin_kodi/entrypoint/default.py
@@ -27,7 +27,12 @@ from ..helper import (
     JSONRPC,
     LazyLogger,
 )
-from ..helper.utils import JsonDebugPrinter, translate_path, kodi_version, path_replacements
+from ..helper.utils import (
+    JsonDebugPrinter,
+    translate_path,
+    kodi_version,
+    path_replacements
+)
 from ..jellyfin import Jellyfin
 
 #################################################################################################

--- a/jellyfin_kodi/entrypoint/default.py
+++ b/jellyfin_kodi/entrypoint/default.py
@@ -27,7 +27,7 @@ from ..helper import (
     JSONRPC,
     LazyLogger,
 )
-from ..helper.utils import JsonDebugPrinter, translate_path, kodi_version
+from ..helper.utils import JsonDebugPrinter, translate_path, kodi_version, path_replacements
 from ..jellyfin import Jellyfin
 
 #################################################################################################
@@ -167,6 +167,8 @@ class Events(object):
             get_themes(api_client)
         elif mode == "managelibs":
             manage_libraries()
+        elif mode == "managepaths":
+            path_replacements()
         elif mode == "backup":
             backup()
         elif mode == "restartservice":
@@ -278,6 +280,7 @@ def listing():
             )
 
     directory(translate(33194), "plugin://plugin.video.jellyfin/?mode=managelibs", True)
+    directory(translate(33203), "plugin://plugin.video.jellyfin/?mode=managepaths", True)
     directory(translate(33134), "plugin://plugin.video.jellyfin/?mode=addserver", False)
     directory(translate(33054), "plugin://plugin.video.jellyfin/?mode=adduser", False)
     directory(translate(5), "plugin://plugin.video.jellyfin/?mode=settings", False)

--- a/jellyfin_kodi/helper/api.py
+++ b/jellyfin_kodi/helper/api.py
@@ -4,6 +4,8 @@ from __future__ import division, absolute_import, print_function, unicode_litera
 ##################################################################################################
 
 from . import settings, LazyLogger
+from .utils import translate_path
+import json
 
 ##################################################################################################
 
@@ -19,6 +21,17 @@ class API(object):
         """
         self.item = item
         self.server = server
+
+        addon_data = translate_path(
+            "special://profile/addon_data/plugin.video.jellyfin/data.json"
+        )
+        try:
+            with open(addon_data, "rb") as infile:
+                data = json.load(infile)
+            self.path_data = data["Servers"][0].get("paths", {})
+        except Exception as e:
+            LOG.warning("Addon appears to not be configured yet: {}".format(e))
+
 
     def get_playcount(self, played, playcount):
         """Convert Jellyfin played/playcount into
@@ -228,6 +241,11 @@ class API(object):
         if "://" in path:
             protocol = path.split("://")[0]
             path = path.replace(protocol, protocol.lower())
+
+        # Loop through configured path replacements searching for a match
+        for local_path in self.path_data.keys():
+            if local_path in path:
+                path = path.replace(local_path, self.path_data[local_path])
 
         return path
 

--- a/jellyfin_kodi/helper/api.py
+++ b/jellyfin_kodi/helper/api.py
@@ -32,7 +32,6 @@ class API(object):
         except Exception as e:
             LOG.warning("Addon appears to not be configured yet: {}".format(e))
 
-
     def get_playcount(self, played, playcount):
         """Convert Jellyfin played/playcount into
         the Kodi equivalent. The playcount is tied to the watch status.

--- a/jellyfin_kodi/helper/utils.py
+++ b/jellyfin_kodi/helper/utils.py
@@ -482,8 +482,48 @@ def set_addon_mode():
 
     if value:
         dialog("ok", "{jellyfin}", translate(33145))
+        path_replacements()
 
     LOG.info("Add-on playback: %s", settings("useDirectPaths") == "0")
+
+
+def path_replacements():
+    # UI to display and manage path replacements for native mode
+    from ..database import get_credentials, save_credentials
+
+    # Retrieve existing stored paths
+    credentials = get_credentials()
+    if credentials['Servers']:
+        paths = credentials["Servers"][0].get("paths", {})
+    else:
+        paths = {}
+    selected_path = 1
+
+    # 0 is Finish, -1 is Cancel
+    while selected_path not in [0, -1]:
+        replace_paths = [ f'{x} : {paths[x]}' for x in paths.keys() ]
+        # Insert a "Finish" entry first, and an "Add" entry second
+        replace_paths.insert(0, translate(33204))
+        replace_paths.insert(1, translate(33205))
+        selected_path = dialog("select", translate(33203), replace_paths)
+        if selected_path == 1:
+            # Add a new path replacement
+            remote_path = dialog("input", translate(33206))
+            local_path = dialog("input", translate(33207))
+            if remote_path and local_path:
+                paths[remote_path] = local_path
+        elif selected_path > 1:
+            # Edit an existing path replacement
+            edit_remote_path = list(paths.keys())[selected_path - 2]
+            edit_local_path = paths[edit_remote_path]
+            # Prepopulate the text box with the existing value
+            remote_path = dialog("input", translate(33206), defaultt=edit_remote_path)
+            local_path = dialog("input", translate(33207), defaultt=edit_local_path)
+            if remote_path and local_path:
+                paths[remote_path] = local_path
+
+    credentials["Servers"][0]["paths"] = paths
+    save_credentials(credentials)
 
 
 class JsonDebugPrinter(object):

--- a/jellyfin_kodi/helper/utils.py
+++ b/jellyfin_kodi/helper/utils.py
@@ -493,7 +493,7 @@ def path_replacements():
 
     # Retrieve existing stored paths
     credentials = get_credentials()
-    if credentials['Servers']:
+    if credentials["Servers"]:
         paths = credentials["Servers"][0].get("paths", {})
     else:
         paths = {}
@@ -501,7 +501,7 @@ def path_replacements():
 
     # 0 is Finish, -1 is Cancel
     while selected_path not in [0, -1]:
-        replace_paths = [ f'{x} : {paths[x]}' for x in paths.keys() ]
+        replace_paths = [f"{x} : {paths[x]}" for x in paths.keys()]
         # Insert a "Finish" entry first, and an "Add" entry second
         replace_paths.insert(0, translate(33204))
         replace_paths.insert(1, translate(33205))
@@ -516,6 +516,8 @@ def path_replacements():
             # Edit an existing path replacement
             edit_remote_path = list(paths.keys())[selected_path - 2]
             edit_local_path = paths[edit_remote_path]
+            # Deleting the existing path
+            del paths[edit_remote_path]
             # Prepopulate the text box with the existing value
             remote_path = dialog("input", translate(33206), defaultt=edit_remote_path)
             local_path = dialog("input", translate(33207), defaultt=edit_local_path)

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -996,3 +996,23 @@ msgstr "Max artwork resolution"
 msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transcode H265/HEVC RExt"
+
+msgctxt "#33203"
+msgid "Manage path replacements"
+msgstr "Manage path replacements"
+
+msgctxt "#33204"
+msgid "Finish"
+msgstr "Finish"
+
+msgctxt "#33205"
+msgid "New Path Replacement"
+msgstr "New Path Replacement"
+
+msgctxt "#33206"
+msgid "Remote Path"
+msgstr "Remote Path"
+
+msgctxt "#33207"
+msgid "Local Path"
+msgstr "Local Path"

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -1004,3 +1004,23 @@ msgstr "Max stream bitrate"
 msgctxt "#33202"
 msgid "Transcode H265/HEVC RExt"
 msgstr "Transcode H265/HEVC RExt"
+
+msgctxt "#33203"
+msgid "Manage path replacements"
+msgstr "Manage path replacements"
+
+msgctxt "#33204"
+msgid "Finish"
+msgstr "Finish"
+
+msgctxt "#33205"
+msgid "New Path Replacement"
+msgstr "New Path Replacement"
+
+msgctxt "#33206"
+msgid "Remote Path"
+msgstr "Remote Path"
+
+msgctxt "#33207"
+msgid "Local Path"
+msgstr "Local Path"


### PR DESCRIPTION
I regret this already.

Fixes #936 and #937, supercedes #925 and #926.

Stores path replacement information in the `data.json` file.  Users are prompted to enter path information after selecting native mode from the setup wizard, and have an additional "Manage path replacements" option inside of the addon itself.  No limit as to how many replacements can be added.  Haven't tested with direct NFS/SMB paths because I don't have any set up for it right now, but local path replacement seems to work as intended so no reason to expect they wouldn't.

![2024-11-13_18-35-10](https://github.com/user-attachments/assets/2c6dfa20-3580-44ff-9e49-556e346bca39)

Realistically should have it's own custom menu screens to match the existing popup dialogs instead of the standard listitem selection/input screens, but after staring at the XML required for far too long I don't care enough to figure it out.


fixes #936 
fixes #937 
closes #925 
closes #926