### PR TITLE
Add paging to API/get_items

### DIFF
--- a/jellyfin_kodi/jellyfin/api.py
+++ b/jellyfin_kodi/jellyfin/api.py
@@ -146,10 +146,17 @@ class API(object):
         return self.users("/Items/%s" % item_id)
 
     def get_items(self, item_ids):
-        return self.users(
-            "/Items",
-            params={"Ids": ",".join(str(x) for x in item_ids), "Fields": info()},
-        )
+        all_results = []
+        for i in range(0, len(item_ids), 150):
+            chunk = item_ids[i:i + 150]
+            response = self.users(
+                "/Items",
+                params={"Ids": ",".join(str(x) for x in chunk), "Fields": info()},
+            )
+            if response:
+                all_results.extend(response.get("Items", []))
+        return {"Items": all_results}
+
 
     def get_sessions(self):
         return self.sessions(params={"ControllableByUserId": "{UserId}"})


### PR DESCRIPTION
This fixes getting the error "414 URI Too Long" when sending large playlists to jellyfin-kodi.
