### PR TITLE
Fix default audio stream selection

### DIFF
--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -213,9 +213,10 @@ class PlayUtils(object):
             LOG.info("--[ transcode ]")
             self.transcode(source, audio, subtitle)
 
-        self.info["AudioStreamIndex"] = self.info.get("AudioStreamIndex") or source.get(
-            "DefaultAudioStreamIndex"
+        self.info["AudioStreamIndex"] = self.info.get("AudioStreamIndex") or (
+            source.get("DefaultAudioStreamIndex", 0) - 1
         )
+
         self.info["SubtitleStreamIndex"] = self.info.get(
             "SubtitleStreamIndex"
         ) or source.get("DefaultSubtitleStreamIndex")

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -382,7 +382,7 @@ class Player(xbmc.Player):
             "IsPaused": item["Paused"],
             "IsMuted": item["Muted"],
             "PlaySessionId": item["PlaySessionId"],
-            "AudioStreamIndex": item["AudioStreamIndex"],
+            "AudioStreamIndex": (item["AudioStreamIndex"] + 1),
             "SubtitleStreamIndex": item["SubtitleStreamIndex"],
         }
         item["Server"].jellyfin.session_progress(data)


### PR DESCRIPTION
Discussion thread here: https://forum.jellyfin.org/t-wrong-audio-track-selected-by-default-jellyfin-for-kodi?pid=52729#pid52729

The current implementation does not work on Fire TV devices (Firestick 4k Max, FireCube V3). The issue seems to stem from a race condition in player.py.

If report_playback() -> detect_audio_subs() is called first, the current audio track is defaulted and this is then stored. Later, set_audio_subs() is called and this same audio track is applied. This is what should happen and, I guess, is expected to happen.

On the FireStick, though, this never happens. The set_audio_subs() is called first - which means the DefaultAudioStreamIndex returned by Jellyfin is used. The logic is then not applied correctly and the wrong audio track is applied. Later, report_playback is called, but by then the audio track has already been set incorrectly and so it never corrects itself.

By applying the correct logic to DefaultAudioStreamIndex, this then works as well.

The correct logic, I believe, should be to subtract 1 from the index returned by Jellyfin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected audio stream selection and reporting to ensure accurate playback behavior and synchronization with the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->