### PR TITLE
Update movies.py

### DIFF
--- a/jellyfin_kodi/objects/kodi/movies.py
+++ b/jellyfin_kodi/objects/kodi/movies.py
@@ -158,7 +158,7 @@ class Movies(Kodi):
 
         # Sets all existing movies without a version to standard version
         for entry in self.cursor.fetchall():
-            self.add_videoversion(entry[0], entry[1], "movie", "0", 40400)
+            self.add_videoversion(entry[0], entry[1], "movie", "1", 40400)
             changes = True
 
         LOG.info("Omega database migration is complete")


### PR DESCRIPTION
Hi,

I created this pull request as I was suffering an issue with current kodi nightly. The problem seemed pretty easy to solve, however it is a problem on nightly and I am unsure if the problem will still be there when kodi piers will go stable.

Also, I feel the problem is pretty impactful, changing the type from a now unknown to what used to be extras (I guess) makes me feel you don't want to merge this for Omega.

Anyhow, this is what is fixing the issue for me on piers right now. It might tame the dragons before they go wild. Hope you want to merge it but no hard feeling if you take omega a priority.

Reference: https://forum.jellyfin.org/t-bug-when-using-current-kodi-nighly
Since kodi piers standard version is changed to 1.
Source from the MyVideosDatabase and https://github.com/xbmc/xbmc/blob/c0be4a8e34263cb939e453dbb4ce3430b46a458c/xbmc/video/VideoManagerTypes.h#L21