### PR TITLE
Remove setting of `StartPercent` 

### DIFF
--- a/jellyfin_kodi/objects/actions.py
+++ b/jellyfin_kodi/objects/actions.py
@@ -508,9 +508,6 @@ class Actions(object):
 
             if obj["Resume"] and item.get("resumePlayback"):
                 listitem.setProperty("resumetime", str(obj["Resume"]))
-                listitem.setProperty(
-                    "StartPercent", str(((obj["Resume"] / obj["Runtime"]) * 100) - 0.40)
-                )
             else:
                 listitem.setProperty("resumetime", "0")
                 listitem.setProperty("StartPercent", "0")


### PR DESCRIPTION
Setting `StartPercent` and with a random 0.4% offset makes no sense given an accurate `resumetime` is available.

See discussion here: https://github.com/jellyfin/jellyfin-kodi/issues/912#issuecomment-3392922726



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video resume behavior: playback now relies on the saved resume time without using or showing an inconsistent start percentage, delivering more consistent start positions and clearer resume indicators. When not resuming, videos start from the beginning as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->