### PR TITLE
Remove angelblue05 from the plugin provider name

### DIFF
--- a/.build/template.xml
+++ b/.build/template.xml
@@ -2,7 +2,7 @@
 <addon id="plugin.video.jellyfin"
 	name="Jellyfin"
 	version=""
-	provider-name="Jellyfin Contributors, angelblue05">
+	provider-name="Jellyfin Contributors">
 	<requires>
 	</requires>
 	<extension point="xbmc.python.pluginsource"


### PR DESCRIPTION
angelblue05, while the primary maintainer before the fork, has not been responsible for issues in this plugin for a long time.
I think it is high time we remove them from here.
Attribution is properly preserved in git history.

This info is primarily displayed in the plugin listing and plugin info page
<img width="1754" height="106" alt="image" src="https://github.com/user-attachments/assets/52a8449d-9378-415e-9992-c7db79482b89" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/5933e1ae-cb2b-4efd-965b-9a9dc7cbd0ff" />

cc @angelblue05 