### PR TITLE
Escape null character in log output

### DIFF
--- a/jellyfin_kodi/helper/loghandler.py
+++ b/jellyfin_kodi/helper/loghandler.py
@@ -65,6 +65,10 @@ class LogHandler(logging.StreamHandler):
                 for token in self.sensitive["Token"]:
                     string = string.replace(token or "{token}", "{jellyfin-token}")
 
+            # Kodi chokes on null-characters in log output, escape it.
+            if "\x00" in string:
+                string = string.replace("\x00", "\ufffdx00\ufffd")
+
             xbmc.log(string, level=self.level)
 
     @classmethod


### PR DESCRIPTION
Fixes #1040

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log output handling by properly escaping special characters to prevent potential log corruption and ensure better compatibility with the Kodi environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->