### PR TITLE
fix: strm file with local file path fails to play

### DIFF
--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -194,17 +194,17 @@ class PlayUtils(object):
         if (
             source.get("Protocol") == "Http"
             or source["SupportsDirectPlay"]
-            and (
-                self.is_strm(source)
-                or not settings("playFromStream.bool")
-                and self.is_file_exists(source)
-            )
+            and (not settings("playFromStream.bool") and self.is_file_exists(source))
         ):
 
             LOG.info("--[ direct play ]")
             self.direct_play(source)
 
-        elif source["SupportsDirectStream"] or source["SupportsDirectPlay"]:
+        elif (
+            self.is_strm(source)
+            or source["SupportsDirectStream"]
+            or source["SupportsDirectPlay"]
+        ):
 
             LOG.info("--[ direct stream ]")
             self.direct_url(source)


### PR DESCRIPTION
this should fix https://github.com/jellyfin/jellyfin-kodi/issues/1084

I will continue testing for a few more days. If no issues arise, I will update this PR.