### PR TITLE
Select mp4 container when transcoding to AV1

### DIFF
--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -278,6 +278,9 @@ class PlayUtils(object):
                 audio_bitrate,
             )
 
+            if "av1" in self.get_transcoding_video_codec():
+                params += "&SegmentContainer=mp4"
+
             video_type = "live" if source["Protocol"] == "LiveTV" else "master"
             base = base.replace(
                 "stream" if "stream" in base else "master", video_type, 1


### PR DESCRIPTION
Presently, when transcoding to AV1 the video stream is put into an unsupported container.  This causes video playback to fail while audio works.

This pull request will cause the transcode to use the correct fmp4 format.

On Kodi V21 playback is successful, however skipping ahead fails.

On Kodi V22 playback/ skipping works as expected (tested on https://mirrors.kodi.tv/nightlies/android/arm/master/kodi-20260125-ff04cfb3-master-armeabi-v7a.apk).

Fixes: https://github.com/jellyfin/jellyfin/issues/15646