### PR TITLE
Don't assume Path always exists in playback objects

### DIFF
--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -166,7 +166,7 @@ class PlayUtils(object):
 
     def is_strm(self, source):
 
-        if source.get("Container") == "strm" or self.item.get("Path","").endswith(".strm"):
+        if source.get("Container") == "strm" or self.item.get("Path", "").endswith(".strm"):
             LOG.info("strm detected")
 
             return True


### PR DESCRIPTION
Fixes problem I found when attempting to test #1095.  livetv sources from ersatz (likely other sources as well) don't contain a Path field and was throwing an exception.