### PR TITLE
music.py: fix addition of song artist different from album artist

### DIFF
--- a/jellyfin_kodi/objects/music.py
+++ b/jellyfin_kodi/objects/music.py
@@ -38,7 +38,7 @@ class Music(KodiDb):
 
     @stop
     @jellyfin_item
-    def artist(self, item, e_item):
+    def artist(self, item, e_item, library=None):
         """If item does not exist, entry will be added.
         If item exists, entry will be updated.
         """
@@ -56,7 +56,7 @@ class Music(KodiDb):
         except TypeError:
             update = False
 
-            library = self.library or find_library(self.server, item)
+            library = library or self.library or find_library(self.server, item)
             if not library:
                 # This item doesn't belong to a whitelisted library
                 return
@@ -426,7 +426,10 @@ class Music(KodiDb):
             except TypeError:
 
                 try:
-                    self.artist(self.server.jellyfin.get_item(temp_obj["Id"]))
+                    self.artist(
+                        self.server.jellyfin.get_item(temp_obj["Id"]),
+                        library={"Id": obj["LibraryId"], "Name": obj["LibraryName"]},
+                    )
                     temp_obj["ArtistId"] = self.jellyfin_db.get_item_by_id(
                         *values(temp_obj, QUEM.get_item_obj)
                     )[0]
@@ -463,7 +466,10 @@ class Music(KodiDb):
             except TypeError:
 
                 try:
-                    self.artist(self.server.jellyfin.get_item(temp_obj["Id"]))
+                    self.artist(
+                        self.server.jellyfin.get_item(temp_obj["Id"]),
+                        library={"Id": obj["LibraryId"], "Name": obj["LibraryName"]},
+                    )
                     temp_obj["ArtistId"] = self.jellyfin_db.get_item_by_id(
                         *values(temp_obj, QUEM.get_item_obj)
                     )[0]


### PR DESCRIPTION
When adding a Various Artists album (or an album with guest artists) where song artists are different from the album artist, the codepath followed to add the artist if it's missing was broken:

```python
  Traceback (most recent call last):
    File "jellyfin_kodi/objects/music.py", line 460, in song_artist_link
      temp_obj["ArtistId"] = self.jellyfin_db.get_item_by_id(
  TypeError: 'NoneType' object is not subscriptable

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "jellyfin_kodi/objects/music.py", line 467, in song_artist_link
      temp_obj["ArtistId"] = self.jellyfin_db.get_item_by_id(
    TypeError: 'NoneType' object is not subscriptable
```

Passing the library used for the song when trying to fetch the artist so that it's used fixes this for me.

Fixes #913 and #837