### PR TITLE
queries_music: update album title when album updated in jellyfin

### DIFF
--- a/jellyfin_kodi/objects/kodi/queries_music.py
+++ b/jellyfin_kodi/objects/kodi/queries_music.py
@@ -203,23 +203,24 @@ VALUES                      (?, ?, ?)
 update_discography_obj = ["{ArtistId}", "{Title}", "{Year}"]
 update_album = """
 UPDATE      album
-SET         strArtists = ?, iYear = ?, strGenres = ?, strReview = ?, strImage = ?,
+SET         strAlbum = ?, strArtists = ?, iYear = ?, strGenres = ?, strReview = ?, strImage = ?,
             iUserrating = ?, lastScraped = ?, strReleaseType = ?
 WHERE       idAlbum = ?
 """
 update_album72 = """
 UPDATE      album
-SET         strArtistDisp = ?, iYear = ?, strGenres = ?, strReview = ?, strImage = ?,
+SET         strAlbum = ?, strArtistDisp = ?, iYear = ?, strGenres = ?, strReview = ?, strImage = ?,
             iUserrating = ?, lastScraped = ?, bScrapedMBID = 1, strReleaseType = ?
 WHERE       idAlbum = ?
 """
 update_album74 = """
 UPDATE      album
-SET         strArtistDisp = ?, strReleaseDate = ?, strGenres = ?, strReview = ?, strImage = ?,
+SET         strAlbum = ?, strArtistDisp = ?, strReleaseDate = ?, strGenres = ?, strReview = ?, strImage = ?,
             iUserrating = ?, lastScraped = ?, bScrapedMBID = 1, strReleaseType = ?
 WHERE       idAlbum = ?
 """
 update_album_obj = [
+    "{Title}",
     "{Artists}",
     "{Year}",
     "{Genre}",


### PR DESCRIPTION
When adding a new album to jellyfin, if jellyfin-kodi adds it to the Kodi database before all metadata is fetched in the Jellyfin server, it is possible that it uses the directory name as the album name, as that's what the server uses before all metadata is loaded.

Once jellyfin updates the metadata, jellyfin-kodi does an update to the album and its tracks, but during this update the album name is not updated. This can leave the directory name as the album name in Kodi.

This patch fixes this by adding the album title to the data that is modified in tue queries to update an album.

Fixes #763