### PR TITLE
Support "GuestStar" person type in TV episode actors

### DIFF
--- a/jellyfin_kodi/helper/api.py
+++ b/jellyfin_kodi/helper/api.py
@@ -57,8 +57,8 @@ class API(object):
 
         if "People" in self.item:
             self.get_people_artwork(self.item["People"])
-            
-            # Define which types of people are considered "actors" in a "cast".
+
+            # Define the types of people considered "actors" in a "cast".
             cast_types = ["Actor", "GuestStar"]
 
             for person in self.item["People"]:

--- a/jellyfin_kodi/objects/kodi/kodi.py
+++ b/jellyfin_kodi/objects/kodi/kodi.py
@@ -137,8 +137,8 @@ class Kodi(object):
         cast_order = 1
 
         bulk_updates = {}
-        
-        # Define which types of people are considered "actors" in a "cast".
+
+        # Define the types of people considered "actors" in a "cast".
         cast_types = ["Actor", "GuestStar"]
 
         for person in people:


### PR DESCRIPTION
This PR ensures that guest stars are included in the cast. This affects TV shows where you typically have regular cast members (stored in Jellyfin data model as people with the type of "Actor") and guest roles (type "GuestStar").

Contrary to Jellyfin, Kodi does not make this distinction, both regular cast and guest stars are treated as Actors and both are displayed on the Information Page of a TV show. Typically only on Episode level, but sometimes also on Season level.

I'm submitting this PR to enable parity between Jellyfin, which does show guest stars in the native apps, and Kodi, which natively also shows guest stars.

Change summary:
- Updated the people-filtering logic to include the GuestStar type.
- Mapped GuestStar to the standard Actor SQL update logic to preserve Role/Character names and Cast Order.

Fixes https://github.com/jellyfin/jellyfin-kodi/issues/1109
