### PR TITLE
Decouple segment checking from playback reporting

### DIFF
--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -33,8 +33,6 @@ class Player(xbmc.Player):
 
     def __init__(self):
         xbmc.Player.__init__(self)
-        self.segment_checker = SegmentChecker(player=self)
-        self.segment_checker.start()
 
     def get_playing_file(self):
         try:
@@ -56,13 +54,15 @@ class Player(xbmc.Player):
         Accounts for scenario where Kodi starts playback and exits immediately.
         First, ensure previous playback terminated correctly in Jellyfin.
         """
+
         self.stop_playback()
-        self.up_next = False
+        self._reset_state()
         count = 0
         monitor = xbmc.Monitor()
 
         try:
             current_file = self.getPlayingFile()
+
         except Exception:
 
             while count < 5:
@@ -728,3 +728,27 @@ class Player(xbmc.Player):
             except Exception:
                 pass
             self.skip_dialog = None
+
+    def _reset_state(self):
+        self._reset_segment_checker()
+        self._reset_skip_dialog()
+
+        self.up_next = False
+        self.skip_segments = {}
+        self.skip_prompted = set()
+
+    def _reset_segment_checker(self):
+        if self.segment_checker:
+            self.segment_checker.stop()
+
+        self.segment_checker = SegmentChecker(player=self)
+        self.segment_checker.start()
+
+    def _reset_skip_dialog(self):
+        if self.skip_dialog:
+            try:
+                self.skip_dialog.close()
+            except Exception:
+                pass
+
+        self.skip_dialog = None

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -13,6 +13,7 @@ from .helper import translate, api, window, settings, dialog, event, JSONRPC
 from .jellyfin import Jellyfin
 from .helper import LazyLogger
 from .helper.utils import translate_path
+from .segments import SegmentChecker
 
 #################################################################################################
 
@@ -28,9 +29,12 @@ class Player(xbmc.Player):
     skip_segments = {}
     skip_prompted = set()
     skip_dialog = None
+    segment_checker = None
 
     def __init__(self):
         xbmc.Player.__init__(self)
+        self.segment_checker = SegmentChecker(player=self)
+        self.segment_checker.start()
 
     def get_playing_file(self):
         try:
@@ -357,9 +361,6 @@ class Player(xbmc.Player):
         if window("jellyfin.external.bool"):
             return
 
-        if settings("mediaSegmentsEnabled.bool"):
-            self.check_skip_segments(item, item["CurrentPosition"])
-
         if not report:
             previous = item["CurrentPosition"]
 
@@ -430,6 +431,9 @@ class Player(xbmc.Player):
         """Stop all playback. Check for external player for positionticks."""
         if not self.played:
             return
+
+        if self.segment_checker:
+            self.segment_checker.stop()
 
         LOG.info("Played info: %s", self.played)
 

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -56,7 +56,7 @@ class Player(xbmc.Player):
         """
 
         self.stop_playback()
-        self._reset_state()
+        self._reset_state(restart=True)
         count = 0
         monitor = xbmc.Monitor()
 
@@ -432,8 +432,7 @@ class Player(xbmc.Player):
         if not self.played:
             return
 
-        if self.segment_checker:
-            self.segment_checker.stop()
+        self._reset_state()
 
         LOG.info("Played info: %s", self.played)
 
@@ -513,12 +512,7 @@ class Player(xbmc.Player):
         self.skip_segments.pop(item_id, None)
         self.skip_prompted = set()
 
-        if self.skip_dialog:
-            try:
-                self.skip_dialog.close()
-            except Exception:
-                pass
-            self.skip_dialog = None
+        self._reset_skip_dialog()
 
         segments = item["Server"].jellyfin.get_media_segments(item_id)
         if segments:
@@ -710,11 +704,7 @@ class Player(xbmc.Player):
             import xbmcaddon
             from .dialogs.skip import SkipDialog
 
-            if self.skip_dialog:
-                try:
-                    self.skip_dialog.close()
-                except Exception:
-                    pass
+            self._reset_skip_dialog()
 
             addon_path = xbmcaddon.Addon("plugin.video.jellyfin").getAddonInfo("path")
             LOG.debug("_show_skip_button: addon_path=%s", addon_path)
@@ -769,27 +759,23 @@ class Player(xbmc.Player):
                 break
 
         LOG.debug("_monitor_skip_dialog: exiting loop")
-        if self.skip_dialog:
-            try:
-                self.skip_dialog.close()
-            except Exception:
-                pass
-            self.skip_dialog = None
+        self._reset_skip_dialog()
 
-    def _reset_state(self):
-        self._reset_segment_checker()
+    def _reset_state(self, restart=False):
+        self._reset_segment_checker(restart)
         self._reset_skip_dialog()
 
         self.up_next = False
         self.skip_segments = {}
         self.skip_prompted = set()
 
-    def _reset_segment_checker(self):
+    def _reset_segment_checker(self, restart=False):
         if self.segment_checker:
             self.segment_checker.stop()
 
-        self.segment_checker = SegmentChecker(player=self)
-        self.segment_checker.start()
+        if restart:
+            self.segment_checker = SegmentChecker(player=self)
+            self.segment_checker.start()
 
     def _reset_skip_dialog(self):
         if self.skip_dialog:

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -33,8 +33,6 @@ class Player(xbmc.Player):
 
     def __init__(self):
         xbmc.Player.__init__(self)
-        self.segment_checker = SegmentChecker(player=self)
-        self.segment_checker.start()
 
     def get_playing_file(self):
         try:
@@ -56,13 +54,15 @@ class Player(xbmc.Player):
         Accounts for scenario where Kodi starts playback and exits immediately.
         First, ensure previous playback terminated correctly in Jellyfin.
         """
+
         self.stop_playback()
-        self.up_next = False
+        self._reset_state()
         count = 0
         monitor = xbmc.Monitor()
 
         try:
             current_file = self.getPlayingFile()
+
         except Exception:
 
             while count < 5:
@@ -775,3 +775,27 @@ class Player(xbmc.Player):
             except Exception:
                 pass
             self.skip_dialog = None
+
+    def _reset_state(self):
+        self._reset_segment_checker()
+        self._reset_skip_dialog()
+
+        self.up_next = False
+        self.skip_segments = {}
+        self.skip_prompted = set()
+
+    def _reset_segment_checker(self):
+        if self.segment_checker:
+            self.segment_checker.stop()
+
+        self.segment_checker = SegmentChecker(player=self)
+        self.segment_checker.start()
+
+    def _reset_skip_dialog(self):
+        if self.skip_dialog:
+            try:
+                self.skip_dialog.close()
+            except Exception:
+                pass
+
+        self.skip_dialog = None

--- a/jellyfin_kodi/segments.py
+++ b/jellyfin_kodi/segments.py
@@ -1,0 +1,37 @@
+from __future__ import division, absolute_import, print_function, unicode_literals
+
+import threading
+import time
+from .helper import LazyLogger, settings
+
+LOG = LazyLogger(__name__)
+
+
+class SegmentChecker(threading.Thread):
+    stop_thread = False
+
+    def __init__(self, player):
+        self.player = player
+
+        threading.Thread.__init__(self)
+
+    def stop(self):
+        self.stop_thread = True
+
+    def run(self):
+        LOG.info("--->[ segment checker ]")
+
+        while not self.stop_thread:
+            try:
+                if settings("mediaSegmentsEnabled.bool"):
+                    current_file = self.player.get_playing_file()
+                    item = self.player.get_file_info(current_file)
+                    current_pos = int(self.player.getTime())
+                    self.player.check_skip_segments(item, current_pos)
+
+            except Exception as e:
+                LOG.error("Error in segment checker loop: %s", e)
+
+            time.sleep(0.2)
+
+        LOG.info("---<[ segment checker ]")

--- a/jellyfin_kodi/segments.py
+++ b/jellyfin_kodi/segments.py
@@ -22,9 +22,10 @@ class SegmentChecker(threading.Thread):
         LOG.info("--->[ segment checker ]")
 
         while not self.stop_thread:
-            item = self._getCurrentPlayingItem()
-            if item and settings("mediaSegmentsEnabled.bool"):
+            if self.player.isPlaying() and settings("mediaSegmentsEnabled.bool"):
                 try:
+                    current_file = self.player.get_playing_file()
+                    item = self.player.get_file_info(current_file)
                     current_pos = int(self.player.getTime())
                     self.player.check_skip_segments(item, current_pos)
 
@@ -34,11 +35,3 @@ class SegmentChecker(threading.Thread):
             xbmc.sleep(1000)
 
         LOG.info("---<[ segment checker ]")
-
-    def _getCurrentPlayingItem(self):
-        try:
-            current_file = self.player.get_playing_file()
-            item = self.player.get_file_info(current_file)
-            return item
-        except Exception:
-            return None

--- a/jellyfin_kodi/segments.py
+++ b/jellyfin_kodi/segments.py
@@ -1,7 +1,7 @@
 from __future__ import division, absolute_import, print_function, unicode_literals
 
 import threading
-import time
+import xbmc
 from .helper import LazyLogger, settings
 
 LOG = LazyLogger(__name__)
@@ -22,16 +22,23 @@ class SegmentChecker(threading.Thread):
         LOG.info("--->[ segment checker ]")
 
         while not self.stop_thread:
-            try:
-                if settings("mediaSegmentsEnabled.bool"):
-                    current_file = self.player.get_playing_file()
-                    item = self.player.get_file_info(current_file)
+            item = self._getCurrentPlayingItem()
+            if item and settings("mediaSegmentsEnabled.bool"):
+                try:
                     current_pos = int(self.player.getTime())
                     self.player.check_skip_segments(item, current_pos)
 
-            except Exception as e:
-                LOG.error("Error in segment checker loop: %s", e)
+                except Exception as e:
+                    LOG.exception("Error in segment checker loop: %s", e)
 
-            time.sleep(0.2)
+            xbmc.sleep(1000)
 
         LOG.info("---<[ segment checker ]")
+
+    def _getCurrentPlayingItem(self):
+        try:
+            current_file = self.player.get_playing_file()
+            item = self.player.get_file_info(current_file)
+            return item
+        except Exception:
+            return None

--- a/jellyfin_kodi/segments.py
+++ b/jellyfin_kodi/segments.py
@@ -25,9 +25,12 @@ class SegmentChecker(threading.Thread):
             if self.player.isPlaying() and settings("mediaSegmentsEnabled.bool"):
                 try:
                     current_file = self.player.get_playing_file()
-                    item = self.player.get_file_info(current_file)
-                    current_pos = int(self.player.getTime())
-                    self.player.check_skip_segments(item, current_pos)
+                    if self.player.is_playing_file(current_file):
+                        item = self.player.get_file_info(current_file)
+                        current_pos = int(self.player.getTime())
+                        self.player.check_skip_segments(item, current_pos)
+                    else:
+                        LOG.info("Current file is not yet playing: %s", current_file)
 
                 except Exception as e:
                     LOG.exception("Error in segment checker loop: %s", e)


### PR DESCRIPTION
Decouple the segment checking logic into a thread that can poll for segments more often than the playback reporting does. The idea for doing this is based on how library.py does things.

Fixes #1104