### PR TITLE
Fix: Sync theme media for TV Tunes add-on

### DIFF
--- a/jellyfin_kodi/entrypoint/default.py
+++ b/jellyfin_kodi/entrypoint/default.py
@@ -1159,9 +1159,9 @@ def get_themes(api_client):
     if not xbmcvfs.exists(library + "/"):
         xbmcvfs.mkdir(library)
 
-    if xbmc.getCondVisibility("System.HasAddon(script.tvtunes)"):
+    if xbmc.getCondVisibility("System.HasAddon(service.tvtunes)"):
 
-        tvtunes = xbmcaddon.Addon(id="script.tvtunes")
+        tvtunes = xbmcaddon.Addon(id="service.tvtunes")
         tvtunes.setSetting("custom_path_enable", "true")
         tvtunes.setSetting("custom_path", library)
         LOG.info("TV Tunes custom path is enabled and set.")

--- a/jellyfin_kodi/entrypoint/default.py
+++ b/jellyfin_kodi/entrypoint/default.py
@@ -1197,9 +1197,12 @@ def get_themes(api_client):
             items[item["Id"]] = folder
 
     for item in items:
+        folder_name = items[item]
+        if isinstance(folder_name, bytes):
+            folder_name = folder_name.decode("utf-8")
 
-        nfo_path = os.path.join(library, items[item])
-        nfo_file = os.path.join(nfo_path, "tvtunes.nfo")
+        nfo_path = os.path.join(str(library), folder_name)
+        nfo_file = os.path.join(str(nfo_path), "tvtunes.nfo")
 
         if not xbmcvfs.exists(nfo_path):
             xbmcvfs.mkdir(nfo_path)

--- a/jellyfin_kodi/helper/xmls.py
+++ b/jellyfin_kodi/helper/xmls.py
@@ -26,7 +26,7 @@ def tvtunes_nfo(path, urls):
     except Exception:
         xml = etree.Element("tvtunes")
 
-    for elem in xml.getiterator("tvtunes"):
+    for elem in xml.iter("tvtunes"):
         for file in list(elem):
             elem.remove(file)
 


### PR DESCRIPTION
The **Sync Theme Media** option in the Jellyfin-Kodi add-on menu doesn't work anymore because it refers to a version of TVTunes that is no longer maintained (and not python 3 compatible). The new maintainer updated the add-on and made it a service instead of a script.

This PR fixes this by:

1. Referring to service.tvtunes
2. Updating the folder creation part to ensure that the path (library + media name) is built using strings instead of a mix between strings and bytes, which threw an error.
3. Updating tvtunes_nfo in xmls.py to refactor the iteration method.

This PR requires further testing. I am only able to confirm that the custom paths created by Sync Theme Media menu option appear logical, **but I don't know if TVTunes is picking it up correctly**. I do also confirm that the NFO files created inside those folders are linking to a correct path (URL) on my Jellyfin server, and that this path leads to an audio file (the theme music) that can be played in the browser). It's looking promising.

Fixes: https://github.com/jellyfin/jellyfin-kodi/issues/1113