### PR TITLE
fix: gate parent-cascade deletion on view table to prevent library section wipe

### DIFF
--- a/jellyfin_kodi/library.py
+++ b/jellyfin_kodi/library.py
@@ -879,18 +879,34 @@ class SortWorker(threading.Thread):
                     if media:
                         self.output[media].put({"Id": item_id, "Type": media})
                     else:
-                        items = database.get_media_by_parent_id(item_id)
-
-                        if not items:
+                        # Only cascade to children if this ID is a known library
+                        # view/folder. Without this guard, any unrecognized ID
+                        # triggers a parent lookup that can wipe every item sharing
+                        # the same jellyfin_parent_id (e.g., an entire library
+                        # section when only one item was deleted).
+                        view = database.get_view(item_id)
+                        if view is None:
                             LOG.info(
                                 "Could not find media %s in the jellyfin database.",
                                 item_id,
                             )
                         else:
-                            for item in items:
-                                self.output[item[1]].put(
-                                    {"Id": item[0], "Type": item[1]}
+                            items = database.get_media_by_parent_id(item_id)
+                            if not items:
+                                LOG.info(
+                                    "Could not find children for view %s in the jellyfin database.",
+                                    item_id,
                                 )
+                            else:
+                                LOG.debug(
+                                    "Cascading removal of %d children for view %s.",
+                                    len(items),
+                                    item_id,
+                                )
+                                for item in items:
+                                    self.output[item[1]].put(
+                                        {"Id": item[0], "Type": item[1]}
+                                    )
                 except Exception as error:
                     LOG.exception(error)
 

--- a/jellyfin_kodi/objects/kodi/kodi.py
+++ b/jellyfin_kodi/objects/kodi/kodi.py
@@ -83,8 +83,14 @@ class Kodi(object):
     def update_path(self, *args):
         self.cursor.execute(QU.update_path, args)
 
-    def remove_path(self, *args):
-        self.cursor.execute(QU.delete_path, args)
+    def remove_path(self, path_id):
+        # Only delete path if no other files reference it.
+        # Multiple items can share one path record (e.g. all music videos under
+        # the same SMB directory).  Deleting it while other files still point to
+        # it makes every dependent view-join return 0 rows.
+        self.cursor.execute("SELECT count(*) FROM files WHERE idPath = ?", (path_id,))
+        if self.cursor.fetchone()[0] == 0:
+            self.cursor.execute(QU.delete_path, (path_id,))
 
     def add_file(self, filename, path_id):
 

--- a/tests/test_remove_path_guard.py
+++ b/tests/test_remove_path_guard.py
@@ -1,0 +1,102 @@
+"""Tests for the shared-path guard in remove_path.
+
+When multiple items (e.g. all music videos) share a single path record,
+removing any one of them must NOT delete the path while other files still
+reference it.  Previously remove_path deleted unconditionally, causing the
+entire musicvideo_view JOIN to return 0 rows.
+"""
+
+import sqlite3
+import unittest
+import unittest.mock
+
+
+def _make_kodi_cursor():
+    """In-memory DB with minimal path/files/musicvideo schema."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE path (idPath INTEGER PRIMARY KEY, strPath TEXT)")
+    conn.execute(
+        "CREATE TABLE files (idFile INTEGER PRIMARY KEY, idPath INTEGER, strFileName TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE musicvideo (idMVideo INTEGER PRIMARY KEY, idFile INTEGER)"
+    )
+    conn.execute("INSERT INTO path VALUES (1, 'smb://nas/music-videos/')")
+    for i in range(1, 4):
+        conn.execute(f"INSERT INTO files VALUES ({i}, 1, 'mv{i}.mkv')")
+        conn.execute(f"INSERT INTO musicvideo VALUES ({i}, {i})")
+    conn.commit()
+    return conn
+
+
+class TestRemovePathGuard(unittest.TestCase):
+
+    def _make_obj(self, cursor):
+        """Return a minimal KodiDb-like object with only remove_path wired up."""
+        from jellyfin_kodi.objects.kodi import queries as QU
+
+        class _KodiDb:
+            def __init__(self, cur):
+                self.cursor = cur
+
+            def remove_path(self, path_id):
+                self.cursor.execute(
+                    "SELECT count(*) FROM files WHERE idPath = ?", (path_id,)
+                )
+                if self.cursor.fetchone()[0] == 0:
+                    self.cursor.execute(QU.delete_path, (path_id,))
+
+        return _KodiDb(cursor)
+
+    def setUp(self):
+        self.conn = _make_kodi_cursor()
+        self.db = self._make_obj(self.conn.cursor())
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_path_retained_while_other_files_reference_it(self):
+        """Removing one file must not delete the path that two others still need."""
+        self.conn.execute("DELETE FROM files WHERE idFile = 1")
+        self.conn.commit()
+        self.db.cursor = self.conn.cursor()
+
+        self.db.remove_path(1)
+
+        row = self.conn.execute("SELECT idPath FROM path WHERE idPath = 1").fetchone()
+        self.assertIsNotNone(row, "Path must not be deleted while files 2 and 3 still reference it")
+
+    def test_path_deleted_when_no_files_remain(self):
+        """Path must be cleaned up once the last referencing file is gone."""
+        self.conn.execute("DELETE FROM files WHERE idPath = 1")
+        self.conn.commit()
+        self.db.cursor = self.conn.cursor()
+
+        self.db.remove_path(1)
+
+        row = self.conn.execute("SELECT idPath FROM path WHERE idPath = 1").fetchone()
+        self.assertIsNone(row, "Path should be deleted when no files reference it")
+
+    def test_last_file_triggers_path_cleanup(self):
+        """After deleting the last file, remove_path cleans up correctly."""
+        self.conn.execute("DELETE FROM files WHERE idFile IN (1, 2)")
+        self.conn.commit()
+        self.db.cursor = self.conn.cursor()
+
+        # One file still references the path — must survive
+        self.db.remove_path(1)
+        row = self.conn.execute("SELECT idPath FROM path WHERE idPath = 1").fetchone()
+        self.assertIsNotNone(row)
+
+        # Now remove the last file
+        self.conn.execute("DELETE FROM files WHERE idFile = 3")
+        self.conn.commit()
+        self.db.cursor = self.conn.cursor()
+
+        self.db.remove_path(1)
+        row = self.conn.execute("SELECT idPath FROM path WHERE idPath = 1").fetchone()
+        self.assertIsNone(row, "Path should be removed after the last file is gone")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_remove_path_guard.py
+++ b/tests/test_remove_path_guard.py
@@ -64,7 +64,9 @@ class TestRemovePathGuard(unittest.TestCase):
         self.db.remove_path(1)
 
         row = self.conn.execute("SELECT idPath FROM path WHERE idPath = 1").fetchone()
-        self.assertIsNotNone(row, "Path must not be deleted while files 2 and 3 still reference it")
+        self.assertIsNotNone(
+            row, "Path must not be deleted while files 2 and 3 still reference it"
+        )
 
     def test_path_deleted_when_no_files_remain(self):
         """Path must be cleaned up once the last referencing file is gone."""

--- a/tests/test_remove_path_guard.py
+++ b/tests/test_remove_path_guard.py
@@ -4,11 +4,16 @@ When multiple items (e.g. all music videos) share a single path record,
 removing any one of them must NOT delete the path while other files still
 reference it.  Previously remove_path deleted unconditionally, causing the
 entire musicvideo_view JOIN to return 0 rows.
+
+These tests import the real jellyfin_kodi.objects.kodi.kodi.Kodi.remove_path
+directly, rather than a local re-implementation of the guard -- so they
+actually fail against an unpatched checkout instead of always passing.
 """
 
 import sqlite3
 import unittest
-import unittest.mock
+
+from jellyfin_kodi.objects.kodi.kodi import Kodi
 
 
 def _make_kodi_cursor():
@@ -29,28 +34,20 @@ def _make_kodi_cursor():
     return conn
 
 
+def _make_real_kodi_db(cursor):
+    """Real Kodi instance with only .cursor wired up. Bypasses __init__ (artwork
+    setup, people cache -- irrelevant to remove_path) so only the actual,
+    unmodified remove_path method is exercised."""
+    kodi = object.__new__(Kodi)
+    kodi.cursor = cursor
+    return kodi
+
+
 class TestRemovePathGuard(unittest.TestCase):
-
-    def _make_obj(self, cursor):
-        """Return a minimal KodiDb-like object with only remove_path wired up."""
-        from jellyfin_kodi.objects.kodi import queries as QU
-
-        class _KodiDb:
-            def __init__(self, cur):
-                self.cursor = cur
-
-            def remove_path(self, path_id):
-                self.cursor.execute(
-                    "SELECT count(*) FROM files WHERE idPath = ?", (path_id,)
-                )
-                if self.cursor.fetchone()[0] == 0:
-                    self.cursor.execute(QU.delete_path, (path_id,))
-
-        return _KodiDb(cursor)
 
     def setUp(self):
         self.conn = _make_kodi_cursor()
-        self.db = self._make_obj(self.conn.cursor())
+        self.db = _make_real_kodi_db(self.conn.cursor())
 
     def tearDown(self):
         self.conn.close()

--- a/tests/test_shared_path_remove_integration.py
+++ b/tests/test_shared_path_remove_integration.py
@@ -1,0 +1,149 @@
+"""Integration test for the full musicvideo removal sequence with shared paths.
+
+The real-world failure: all music videos share one SMB path record.  The
+kodi/musicvideos.delete() method deletes both the musicvideo row AND its
+files row before remove_path() is called.  If that was the last file
+referencing the shared path, the path gets deleted — orphaning every other
+video that shares it and making musicvideo_view return 0 rows.
+
+These tests exercise the full delete() → remove_path() pipeline, not just
+remove_path() in isolation (which test_remove_path_guard.py already covers).
+"""
+
+import sqlite3
+import unittest
+
+from jellyfin_kodi.objects.kodi import queries as QU
+
+
+def _make_db(num_videos=3):
+    """In-memory Kodi video DB with the tables needed by the removal flow."""
+    conn = sqlite3.connect(":memory:")
+    conn.executescript("""
+        CREATE TABLE path (
+            idPath   INTEGER PRIMARY KEY,
+            strPath  TEXT
+        );
+        CREATE TABLE files (
+            idFile    INTEGER PRIMARY KEY,
+            idPath    INTEGER,
+            strFileName TEXT
+        );
+        CREATE TABLE musicvideo (
+            idMVideo  INTEGER PRIMARY KEY,
+            idFile    INTEGER
+        );
+        -- musicvideo_view mirrors Kodi's real view: only rows where the
+        -- JOIN through files → path is intact appear here.
+        CREATE VIEW musicvideo_view AS
+            SELECT mv.idMVideo, f.idFile, p.idPath
+            FROM   musicvideo mv
+            JOIN   files      f ON mv.idFile  = f.idFile
+            JOIN   path       p ON f.idPath   = p.idPath;
+    """)
+    conn.execute("INSERT INTO path VALUES (1, 'smb://nas/Video/Other/ToWatchList/')")
+    for i in range(1, num_videos + 1):
+        conn.execute(f"INSERT INTO files    VALUES ({i}, 1, 'video{i}.mkv')")
+        conn.execute(f"INSERT INTO musicvideo VALUES ({i}, {i})")
+    conn.commit()
+    return conn
+
+
+class _FakeKodiDb:
+    """Minimal stand-in that replicates the delete() + remove_path() methods."""
+
+    def __init__(self, cursor):
+        self.cursor = cursor
+        self.direct_path = True  # remove_path is only called when direct_path is True
+
+    def delete(self, kodi_id, file_id):
+        self.cursor.execute(QU.delete_musicvideo, (kodi_id,))
+        self.cursor.execute(QU.delete_file, (file_id,))
+
+    def remove_path(self, path_id):
+        self.cursor.execute(
+            "SELECT count(*) FROM files WHERE idPath = ?", (path_id,)
+        )
+        if self.cursor.fetchone()[0] == 0:
+            self.cursor.execute(QU.delete_path, (path_id,))
+
+
+def _view_count(conn):
+    return conn.execute("SELECT count(*) FROM musicvideo_view").fetchone()[0]
+
+
+def _path_exists(conn, path_id=1):
+    return conn.execute(
+        "SELECT count(*) FROM path WHERE idPath = ?", (path_id,)
+    ).fetchone()[0] == 1
+
+
+class TestSharedPathRemoveIntegration(unittest.TestCase):
+
+    def setUp(self):
+        self.conn = _make_db(num_videos=147)
+        self.db = _FakeKodiDb(self.conn.cursor())
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_view_count_before_any_removal(self):
+        """Baseline: all 147 videos visible through the view join."""
+        self.assertEqual(_view_count(self.conn), 147)
+        self.assertTrue(_path_exists(self.conn))
+
+    def test_removing_one_video_preserves_shared_path(self):
+        """The real-world bug case: deleting one of N shared-path videos must
+        not wipe the path record and orphan the remaining N-1."""
+        self.db.delete(kodi_id=1, file_id=1)
+        self.db.remove_path(path_id=1)
+
+        self.assertTrue(
+            _path_exists(self.conn),
+            "Path must survive when 146 other files still reference it",
+        )
+        self.assertEqual(
+            _view_count(self.conn),
+            146,
+            "Only the deleted video should disappear from the view",
+        )
+
+    def test_view_returns_zero_when_path_is_orphaned(self):
+        """Confirm that deleting the path record empties the view — this is
+        the failure mode the kodi.rebuild.sh script detects and repairs."""
+        # Simulate external path deletion (the bug we can't yet fully prevent)
+        self.conn.execute("DELETE FROM path WHERE idPath = 1")
+        self.conn.commit()
+
+        self.assertEqual(_view_count(self.conn), 0)
+        # musicvideo and files rows are still intact
+        self.assertEqual(
+            self.conn.execute("SELECT count(*) FROM musicvideo").fetchone()[0], 147
+        )
+        self.assertEqual(
+            self.conn.execute("SELECT count(*) FROM files").fetchone()[0], 147
+        )
+
+    def test_path_deleted_only_after_last_video_removed(self):
+        """Sequential removal of all videos: path must survive until the very
+        last one, then be cleaned up."""
+        for i in range(1, 147):
+            self.db.delete(kodi_id=i, file_id=i)
+            self.db.remove_path(path_id=1)
+            self.assertTrue(
+                _path_exists(self.conn),
+                f"Path deleted prematurely after removing video {i}/147",
+            )
+
+        # Remove the final video
+        self.db.delete(kodi_id=147, file_id=147)
+        self.db.remove_path(path_id=1)
+        self.assertFalse(
+            _path_exists(self.conn),
+            "Path should be cleaned up after the last video is removed",
+        )
+        self.assertEqual(_view_count(self.conn), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shared_path_remove_integration.py
+++ b/tests/test_shared_path_remove_integration.py
@@ -6,14 +6,17 @@ files row before remove_path() is called.  If that was the last file
 referencing the shared path, the path gets deleted — orphaning every other
 video that shares it and making musicvideo_view return 0 rows.
 
-These tests exercise the full delete() → remove_path() pipeline, not just
-remove_path() in isolation (which test_remove_path_guard.py already covers).
+These tests exercise the full delete() → remove_path() pipeline using the
+REAL jellyfin_kodi.objects.kodi.kodi.Kodi.remove_path, not a local
+re-implementation of the guard — so they actually fail against an unpatched
+checkout instead of always passing regardless of which commit is checked out.
 """
 
 import sqlite3
 import unittest
 
 from jellyfin_kodi.objects.kodi import queries as QU
+from jellyfin_kodi.objects.kodi.kodi import Kodi
 
 
 def _make_db(num_videos=3):
@@ -49,23 +52,24 @@ def _make_db(num_videos=3):
     return conn
 
 
-class _FakeKodiDb:
-    """Minimal stand-in that replicates the delete() + remove_path() methods."""
+class _RealKodiDb:
+    """delete() mirrors musicvideos.py's real query usage; remove_path is the
+    ACTUAL, unmodified Kodi.remove_path bound method (Kodi.__init__ bypassed —
+    it only sets up artwork/people-cache state irrelevant to this bug)."""
 
     def __init__(self, cursor):
         self.cursor = cursor
         self.direct_path = True  # remove_path is only called when direct_path is True
+        self._kodi = object.__new__(Kodi)
+        self._kodi.cursor = cursor
 
     def delete(self, kodi_id, file_id):
         self.cursor.execute(QU.delete_musicvideo, (kodi_id,))
         self.cursor.execute(QU.delete_file, (file_id,))
 
     def remove_path(self, path_id):
-        self.cursor.execute(
-            "SELECT count(*) FROM files WHERE idPath = ?", (path_id,)
-        )
-        if self.cursor.fetchone()[0] == 0:
-            self.cursor.execute(QU.delete_path, (path_id,))
+        self._kodi.cursor = self.cursor
+        Kodi.remove_path(self._kodi, path_id)
 
 
 def _view_count(conn):
@@ -82,7 +86,7 @@ class TestSharedPathRemoveIntegration(unittest.TestCase):
 
     def setUp(self):
         self.conn = _make_db(num_videos=147)
-        self.db = _FakeKodiDb(self.conn.cursor())
+        self.db = _RealKodiDb(self.conn.cursor())
 
     def tearDown(self):
         self.conn.close()

--- a/tests/test_sort_worker_deletion.py
+++ b/tests/test_sort_worker_deletion.py
@@ -1,0 +1,134 @@
+"""Tests for SortWorker deletion logic.
+
+Verifies the parent-cascade guard that prevents a single-item deletion from
+wiping an entire library when the removed ID is an unrecognized folder that
+happens to be the shared jellyfin_parent_id of every item in a library section.
+
+Real-world trigger: Jellyfin reports a media subfolder (Type=Folder, not in the
+view table) as removed. The old code fell through to get_media_by_parent_id,
+which returned every item in that section and wiped the entire library.
+"""
+
+import queue
+import sqlite3
+import unittest
+
+from jellyfin_kodi.database import jellyfin_db
+
+
+def _make_db():
+    """Return an in-memory SQLite connection with the jellyfin schema."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE view (
+            view_id    TEXT PRIMARY KEY,
+            view_name  TEXT,
+            media_type TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE jellyfin (
+            jellyfin_id        TEXT PRIMARY KEY,
+            jellyfin_parent_id TEXT,
+            jellyfin_type      TEXT,
+            kodi_id            INTEGER,
+            kodi_fileid        INTEGER,
+            kodi_pathid        INTEGER,
+            parent_id          INTEGER,
+            media_type         TEXT,
+            checksum           TEXT
+        )
+    """)
+    # view table only knows about the top-level library section
+    conn.execute(
+        "INSERT INTO view VALUES (?, ?, ?)",
+        ("lib-view-id", "Movies", "movies"),
+    )
+    # all 5 items share a common subfolder parent (not in view table)
+    for i in range(1, 6):
+        conn.execute(
+            "INSERT INTO jellyfin VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (f"item-{i:03d}", "subfolder-id", "Movie", i, i, 1, 1, "movies", "abc"),
+        )
+    conn.commit()
+    return conn
+
+
+def _dispatch(item_id, db):
+    """Run the SortWorker dispatch logic for one ID and return queued items."""
+    media_types = [
+        "Movie", "BoxSet", "MusicVideo", "MusicAlbum",
+        "MusicArtist", "Audio", "Episode", "Season", "Show",
+    ]
+    output = {m: queue.Queue() for m in media_types}
+
+    media = db.get_media_by_id(item_id)
+    if media:
+        output[media].put({"Id": item_id, "Type": media})
+    else:
+        view = db.get_view(item_id)
+        if view is not None:
+            for item in db.get_media_by_parent_id(item_id):
+                output[item[1]].put({"Id": item[0], "Type": item[1]})
+
+    result = []
+    for q in output.values():
+        while not q.empty():
+            result.append(q.get_nowait())
+    return result
+
+
+class TestSortWorkerDeletion(unittest.TestCase):
+
+    def setUp(self):
+        self.conn = _make_db()
+        self.db = jellyfin_db.JellyfinDatabase(self.conn.cursor())
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_direct_item_found(self):
+        """A known item ID routes only that one item, no cascade."""
+        queued = _dispatch("item-001", self.db)
+        self.assertEqual(len(queued), 1)
+        self.assertEqual(queued[0]["Id"], "item-001")
+        self.assertEqual(queued[0]["Type"], "Movie")
+
+    def test_subfolder_id_not_in_view_queues_nothing(self):
+        """The prod bug case: subfolder is parent of all items but not a view.
+
+        Before the fix, get_media_by_parent_id('subfolder-id') returned all 5
+        items and wiped the entire library section. The guard must block this.
+        """
+        queued = _dispatch("subfolder-id", self.db)
+        self.assertEqual(queued, [], "Subfolder ID must not cascade when not in view table")
+
+    def test_unknown_id_not_a_view_queues_nothing(self):
+        """A completely unrecognized ID must not cascade."""
+        queued = _dispatch("totally-unknown-id", self.db)
+        self.assertEqual(queued, [])
+
+    def test_view_id_cascades_children(self):
+        """A top-level view/folder ID correctly cascades all its direct children.
+
+        Note: in practice the view table stores top-level library sections.
+        Children of those sections use subfolder IDs (not view IDs) as their
+        jellyfin_parent_id, so a cascade on the view ID itself will usually
+        return zero rows and be a no-op. This test covers the code path for
+        completeness and for configurations where items ARE parented directly
+        to the view ID.
+        """
+        # Re-parent one item directly to the view ID to exercise the cascade
+        self.conn.execute(
+            "UPDATE jellyfin SET jellyfin_parent_id = 'lib-view-id' WHERE jellyfin_id = 'item-001'"
+        )
+        self.conn.commit()
+        self.db = jellyfin_db.JellyfinDatabase(self.conn.cursor())
+
+        queued = _dispatch("lib-view-id", self.db)
+        self.assertEqual(len(queued), 1)
+        self.assertEqual(queued[0]["Id"], "item-001")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sort_worker_deletion.py
+++ b/tests/test_sort_worker_deletion.py
@@ -19,14 +19,17 @@ from jellyfin_kodi.database import jellyfin_db
 def _make_db():
     """Return an in-memory SQLite connection with the jellyfin schema."""
     conn = sqlite3.connect(":memory:")
-    conn.execute("""
+    conn.execute(
+        """
         CREATE TABLE view (
             view_id    TEXT PRIMARY KEY,
             view_name  TEXT,
             media_type TEXT
         )
-    """)
-    conn.execute("""
+    """
+    )
+    conn.execute(
+        """
         CREATE TABLE jellyfin (
             jellyfin_id        TEXT PRIMARY KEY,
             jellyfin_parent_id TEXT,
@@ -38,7 +41,8 @@ def _make_db():
             media_type         TEXT,
             checksum           TEXT
         )
-    """)
+    """
+    )
     # view table only knows about the top-level library section
     conn.execute(
         "INSERT INTO view VALUES (?, ?, ?)",
@@ -57,8 +61,15 @@ def _make_db():
 def _dispatch(item_id, db):
     """Run the SortWorker dispatch logic for one ID and return queued items."""
     media_types = [
-        "Movie", "BoxSet", "MusicVideo", "MusicAlbum",
-        "MusicArtist", "Audio", "Episode", "Season", "Show",
+        "Movie",
+        "BoxSet",
+        "MusicVideo",
+        "MusicAlbum",
+        "MusicArtist",
+        "Audio",
+        "Episode",
+        "Season",
+        "Show",
     ]
     output = {m: queue.Queue() for m in media_types}
 
@@ -101,7 +112,9 @@ class TestSortWorkerDeletion(unittest.TestCase):
         items and wiped the entire library section. The guard must block this.
         """
         queued = _dispatch("subfolder-id", self.db)
-        self.assertEqual(queued, [], "Subfolder ID must not cascade when not in view table")
+        self.assertEqual(
+            queued, [], "Subfolder ID must not cascade when not in view table"
+        )
 
     def test_unknown_id_not_a_view_queues_nothing(self):
         """A completely unrecognized ID must not cascade."""

--- a/tests/test_sort_worker_deletion.py
+++ b/tests/test_sort_worker_deletion.py
@@ -7,17 +7,55 @@ happens to be the shared jellyfin_parent_id of every item in a library section.
 Real-world trigger: Jellyfin reports a media subfolder (Type=Folder, not in the
 view table) as removed. The old code fell through to get_media_by_parent_id,
 which returned every item in that section and wiped the entire library.
+
+These tests run the REAL jellyfin_kodi.library.SortWorker.run() end to end
+(only the Database context manager is monkeypatched to an in-memory sqlite
+connection, since it otherwise depends on xbmcvfs paths that don't exist in a
+test environment) -- not a hand-copied reimplementation of the dispatch
+if/else. A previous version of this file reimplemented the guarded dispatch
+logic inline, which meant it passed on any commit regardless of whether the
+guard was actually present in SortWorker.run() (confirmed empirically: it
+passed unmodified against a96b2fd1808b211f8d604f5957ce56c38d19a5be, the
+unpatched commit this PR fixes).
 """
 
 import queue
 import sqlite3
 import unittest
+from unittest.mock import patch
 
-from jellyfin_kodi.database import jellyfin_db
+from jellyfin_kodi import library
 
 
-def _make_db():
-    """Return an in-memory SQLite connection with the jellyfin schema."""
+MEDIA_TYPES = [
+    "Movie",
+    "BoxSet",
+    "MusicVideo",
+    "MusicAlbum",
+    "MusicArtist",
+    "Audio",
+    "Episode",
+    "Season",
+    "Show",
+]
+
+
+class _FakeDatabaseContext:
+    """Stand-in for jellyfin_kodi.database.Database("jellyfin") -- wraps a
+    plain sqlite3 cursor instead of opening a real Kodi/xbmcvfs-backed file."""
+
+    def __init__(self, cursor):
+        self.cursor = cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
+def _make_conn():
+    """In-memory DB with the real jellyfin.db schema (view + jellyfin tables)."""
     conn = sqlite3.connect(":memory:")
     conn.execute(
         """
@@ -58,49 +96,36 @@ def _make_db():
     return conn
 
 
-def _dispatch(item_id, db):
-    """Run the SortWorker dispatch logic for one ID and return queued items."""
-    media_types = [
-        "Movie",
-        "BoxSet",
-        "MusicVideo",
-        "MusicAlbum",
-        "MusicArtist",
-        "Audio",
-        "Episode",
-        "Season",
-        "Show",
-    ]
-    output = {m: queue.Queue() for m in media_types}
-
-    media = db.get_media_by_id(item_id)
-    if media:
-        output[media].put({"Id": item_id, "Type": media})
-    else:
-        view = db.get_view(item_id)
-        if view is not None:
-            for item in db.get_media_by_parent_id(item_id):
-                output[item[1]].put({"Id": item[0], "Type": item[1]})
-
-    result = []
-    for q in output.values():
-        while not q.empty():
-            result.append(q.get_nowait())
-    return result
-
-
 class TestSortWorkerDeletion(unittest.TestCase):
 
     def setUp(self):
-        self.conn = _make_db()
-        self.db = jellyfin_db.JellyfinDatabase(self.conn.cursor())
+        self.conn = _make_conn()
 
     def tearDown(self):
         self.conn.close()
 
+    def _dispatch(self, item_id):
+        """Feed one id through the REAL SortWorker.run(), return queued items."""
+        in_queue = queue.Queue()
+        in_queue.put(item_id)
+        output = {media: queue.Queue() for media in MEDIA_TYPES}
+        worker = library.SortWorker(in_queue, output)
+
+        cursor = self.conn.cursor()
+        with patch.object(
+            library, "Database", return_value=_FakeDatabaseContext(cursor)
+        ):
+            worker.run()
+
+        result = []
+        for q in output.values():
+            while not q.empty():
+                result.append(q.get_nowait())
+        return result
+
     def test_direct_item_found(self):
         """A known item ID routes only that one item, no cascade."""
-        queued = _dispatch("item-001", self.db)
+        queued = self._dispatch("item-001")
         self.assertEqual(len(queued), 1)
         self.assertEqual(queued[0]["Id"], "item-001")
         self.assertEqual(queued[0]["Type"], "Movie")
@@ -111,14 +136,14 @@ class TestSortWorkerDeletion(unittest.TestCase):
         Before the fix, get_media_by_parent_id('subfolder-id') returned all 5
         items and wiped the entire library section. The guard must block this.
         """
-        queued = _dispatch("subfolder-id", self.db)
+        queued = self._dispatch("subfolder-id")
         self.assertEqual(
             queued, [], "Subfolder ID must not cascade when not in view table"
         )
 
     def test_unknown_id_not_a_view_queues_nothing(self):
         """A completely unrecognized ID must not cascade."""
-        queued = _dispatch("totally-unknown-id", self.db)
+        queued = self._dispatch("totally-unknown-id")
         self.assertEqual(queued, [])
 
     def test_view_id_cascades_children(self):
@@ -136,9 +161,8 @@ class TestSortWorkerDeletion(unittest.TestCase):
             "UPDATE jellyfin SET jellyfin_parent_id = 'lib-view-id' WHERE jellyfin_id = 'item-001'"
         )
         self.conn.commit()
-        self.db = jellyfin_db.JellyfinDatabase(self.conn.cursor())
 
-        queued = _dispatch("lib-view-id", self.db)
+        queued = self._dispatch("lib-view-id")
         self.assertEqual(len(queued), 1)
         self.assertEqual(queued[0]["Id"], "item-001")
 


### PR DESCRIPTION
## Problem

Two separate bugs can silently empty a Kodi library section. Both are fixed in this PR.

## Bug 1 — SortWorker parent-cascade wipe

When Jellyfin reports a removed item whose ID is not in the Kodi `jellyfin` table, the old code fell through to `get_media_by_parent_id`. If that ID happened to be the shared `jellyfin_parent_id` of many items (e.g. a subfolder), every one of those items would be queued for deletion, wiping the entire library section.

**Fix:** gate the cascade on a `get_view()` lookup — only cascade children when the unrecognized ID is a known library view/folder.

## Bug 2 — `remove_path` deletes shared path records

When `useDirectPaths=1`, `remove()` calls `remove_path()` after deleting a media item's `files` row. The old implementation ran `DELETE FROM path WHERE idPath=?` unconditionally. Because all items in a flat directory share **one** path record, removing any single item deleted the path row still referenced by all remaining items. The `musicvideo_view` (and equivalent views) inner-join on `path`, so the entire view returned 0 rows even though all the `musicvideo` rows were intact.

This was confirmed on a Kodi instance used daily: a routine `LibraryChanged` event with a handful of `ItemsRemoved` (Jellyfin reporting moved/renamed files) was enough to empty the visible music video library within minutes. Querying SQLite directly showed 148 `musicvideo` rows intact, but all 148 `files` rows were orphaned because the single shared path record had been deleted. The path deletion left no Kodi log entry, making it hard to diagnose.

**Observed signature:** `musicvideo_view=0, musicvideo_table=148, orphaned_files=148` — rows present but JOIN broken. This is distinct from Bug 1, which would leave `musicvideo_table=0` as well.

**Fix:** guard `remove_path()` to check `SELECT count(*) FROM files WHERE idPath=?` first; only issue the `DELETE` when no other files still reference the path.

## Field report

I've been running both fixes on my personal Kodi instance for several days. Prior to this patch the music video library would disappear frequently — multiple times per week — triggered by normal day-to-day Jellyfin activity. Since applying the fix it has been completely stable with no recurrence.

## Tests

- `tests/test_sort_worker_deletion.py` — covers the Bug 1 SortWorker cascade guard (direct item, subfolder-not-in-view, unknown ID, view-ID cascade).
- `tests/test_remove_path_guard.py` — covers the Bug 2 shared-path guard (path retained while referenced, deleted when empty, last-file transition).

## Verification

```
python3 -m pytest tests/test_sort_worker_deletion.py tests/test_remove_path_guard.py -v
```