### PR TITLE
fix(browse): add sort methods inside collections

### DIFF
--- a/jellyfin_kodi/entrypoint/default.py
+++ b/jellyfin_kodi/entrypoint/default.py
@@ -738,6 +738,11 @@ def browse(media, view_id=None, folder=None, server_id=None, api_client=None):
         xbmcplugin.addSortMethod(PROCESS_HANDLE, xbmcplugin.SORT_METHOD_DATE)
         xbmcplugin.addSortMethod(PROCESS_HANDLE, xbmcplugin.SORT_METHOD_VIDEO_RATING)
         xbmcplugin.addSortMethod(PROCESS_HANDLE, xbmcplugin.SORT_METHOD_VIDEO_RUNTIME)
+    elif media in ("boxset", "library"):
+        xbmcplugin.addSortMethod(PROCESS_HANDLE, xbmcplugin.SORT_METHOD_DATE)
+        xbmcplugin.addSortMethod(PROCESS_HANDLE, xbmcplugin.SORT_METHOD_VIDEO_YEAR)
+        xbmcplugin.addSortMethod(PROCESS_HANDLE, xbmcplugin.SORT_METHOD_VIDEO_ORIGINAL_TITLE)
+        xbmcplugin.addSortMethod(PROCESS_HANDLE, xbmcplugin.SORT_METHOD_VIDEO_TITLE)
 
     xbmcplugin.setContent(PROCESS_HANDLE, content_type)
     xbmcplugin.endOfDirectory(PROCESS_HANDLE)


### PR DESCRIPTION
When browsing the contents of a collection, there is no way to re-arrange the contents by any sort order other than title. This change fixes that by adding a few basic sort methods to folders

To test this change, create a collection in which the alphabetical order of items is different from the chronological (by year) order of items. Toggle between the sort methods (now that there are more than one) and observe the difference