### PR TITLE
Fix: Only transcode with mp4 container when the preferred codec is av1 to avoid seeking failure

### DIFF
--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -280,7 +280,8 @@ class PlayUtils(object):
                 audio_bitrate,
             )
 
-            if "av1" in self.get_transcoding_video_codec():
+            # Use mp4 container sparingly due to ffmpeg 6.0.1 seeking bug #7359
+            if settings("videoPreferredCodec") == "AV1":
                 params += "&SegmentContainer=mp4"
 
             video_type = "live" if source["Protocol"] == "LiveTV" else "master"


### PR DESCRIPTION
ffmpeg 6.0.1 fails to seek when using fmp4 in current stable Kodi 21.3 (https://trac.ffmpeg.org/ticket/7359), so it would be better to limit its usage to only when the preferred codec is av1. Since #1094, fmp4 is being used unnecessarily for all codecs by default and breaking seek despite av1 being the lowest priority.