### PR TITLE
Add support for TV show trailers

### DIFF
--- a/jellyfin_kodi/objects/kodi/queries.py
+++ b/jellyfin_kodi/objects/kodi/queries.py
@@ -446,8 +446,8 @@ add_musicvideo_obj = [
     "{Premiere}",
 ]
 add_tvshow = """
-INSERT INTO     tvshow(idShow, c00, c01, c02, c04, c05, c08, c09, c10, c12, c13, c14, c15)
-VALUES          (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO     tvshow(idShow, c00, c01, c02, c04, c05, c08, c09, c10, c12, c13, c14, c15, c16)
+VALUES          (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
 add_tvshow_obj = [
     "{ShowId}",
@@ -463,6 +463,7 @@ add_tvshow_obj = [
     "{Mpaa}",
     "{Studio}",
     "{SortTitle}",
+    "{Trailer}",
 ]
 add_season = """
 INSERT INTO     seasons(idSeason, idShow, season)
@@ -693,7 +694,7 @@ update_musicvideo_obj = [
 update_tvshow = """
 UPDATE      tvshow
 SET         c00 = ?, c01 = ?, c02 = ?, c04 = ?, c05 = ?, c08 = ?, c09 = ?, c10 = ?,
-            c12 = ?, c13 = ?, c14 = ?, c15 = ?
+            c12 = ?, c13 = ?, c14 = ?, c15 = ?, c16 = ?
 WHERE       idShow = ?
 """
 update_tvshow_obj = [
@@ -709,6 +710,7 @@ update_tvshow_obj = [
     "{Mpaa}",
     "{Studio}",
     "{SortTitle}",
+    "{Trailer}",
     "{ShowId}",
 ]
 update_tvshow_link = """

--- a/jellyfin_kodi/objects/movies.py
+++ b/jellyfin_kodi/objects/movies.py
@@ -207,7 +207,7 @@ class Movies(KodiDb):
                 )
         except Exception as error:
 
-            LOG.exception("Failed to get trailer: %s", error)
+            LOG.exception("Failed to get trailer for movie %s: %s", obj["Id"], error)
             obj["Trailer"] = None
 
     def get_path_filename(self, obj):

--- a/jellyfin_kodi/objects/obj_map.json
+++ b/jellyfin_kodi/objects/obj_map.json
@@ -79,7 +79,9 @@
 		"Favorite": "UserData/IsFavorite",
 		"RecursiveCount": "RecursiveItemCount",
 		"JellyfinParentId": "ParentId",
-		"Status": "Status"
+		"Status": "Status",
+		"LocalTrailer": "LocalTrailerCount",
+		"Trailer": "RemoteTrailers/0/Url"
 	},
 	"Season": {
 		"Id": "Id",

--- a/jellyfin_kodi/objects/tvshows.py
+++ b/jellyfin_kodi/objects/tvshows.py
@@ -112,6 +112,7 @@ class TVShows(KodiDb):
         obj["Plot"] = API.get_overview(obj["Plot"])
         obj["Studio"] = " / ".join(obj["Studios"])
         obj["Artwork"] = API.get_all_artwork(self.objects.map(item, "Artwork"))
+        self.trailer(obj)
 
         if obj["Status"] != "Ended":
             obj["Status"] = None
@@ -247,6 +248,26 @@ class TVShows(KodiDb):
         )
 
         self.update_path_parent_id(obj["PathId"], obj["TopPathId"])
+
+    def trailer(self, obj):
+        """Resolve the trailer URL, preferring a locally stored Jellyfin trailer
+        over a remote one.  Mirrors Movies.trailer().
+        """
+        try:
+            if obj["LocalTrailer"]:
+                trailer = self.server.jellyfin.get_local_trailers(obj["Id"])
+                obj["Trailer"] = (
+                    "plugin://plugin.video.jellyfin/trailer?id=%s&mode=play"
+                    % trailer[0]["Id"]
+                )
+            elif obj["Trailer"]:
+                obj["Trailer"] = (
+                    "plugin://plugin.video.youtube/play/?video_id=%s"
+                    % obj["Trailer"].rsplit("=", 1)[1]
+                )
+        except Exception as error:
+            LOG.exception("Failed to get trailer for tvshow %s: %s", obj["Id"], error)
+            obj["Trailer"] = None
 
     def get_path_filename(self, obj):
         """Get the path and build it into protocol://path"""


### PR DESCRIPTION
Kodi Nexus (20) is the earliest version of Kodi that JF for Kodi supports.

Kodi Nexus added support for TV show trailers in the Kodi database.   Skins also support these trailers including e.g. the default Estuary and Confluence.

This PR adds support for syncing TV show trailers from Jellyfin to Kodi.

Users would need to re-sync their TV library or libraries to see the trailers.