### PR TITLE
Fix segment skipping countdown

### DIFF
--- a/jellyfin_kodi/dialogs/skip.py
+++ b/jellyfin_kodi/dialogs/skip.py
@@ -123,3 +123,33 @@ class SkipDialog(xbmcgui.WindowXMLDialog):
     def is_cancel(self):
         """Return whether the user cancelled."""
         return self.cancel_requested
+
+    def update_duration(self, remaining):
+        """Update the remaining duration and label properties dynamically."""
+        if remaining < 0:
+            remaining = 0
+        self._duration = remaining
+
+        # Format duration text
+        minutes = int(remaining // 60)
+        seconds = int(remaining % 60)
+        if minutes > 0:
+            duration_text = "{0}m {1}s".format(minutes, seconds)
+        else:
+            duration_text = "{0}s".format(seconds)
+
+        # Get short segment type label
+        segment_label = SEGMENT_LABELS.get(self._segment_type, self._segment_type or "Segment")
+
+        # Set button label: "Skip Intro (1m 40s)"
+        button_label = "Skip {0} ({1})".format(segment_label, duration_text)
+
+        # Use setProperty so it's available to the skin
+        self.setProperty("skip_label", button_label)
+        self.setProperty("duration", duration_text)
+
+        try:
+            button = self.getControl(SKIP_BUTTON)
+            button.setLabel(button_label)
+        except Exception:
+            pass

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -31,6 +31,8 @@ class Player(xbmc.Player):
 
     def __init__(self):
         xbmc.Player.__init__(self)
+        self._segment_thread = None
+        self._segment_thread_active = False
 
     def get_playing_file(self):
         try:
@@ -133,6 +135,11 @@ class Player(xbmc.Player):
                 self.check_skip_segments(item, current_pos)
             except Exception:
                 pass  # Player may not be ready yet
+
+            try:
+                self._start_segment_monitor(item)
+            except Exception as e:
+                LOG.warning("Failed to start segment monitor thread: %s", e)
 
         if monitor.waitForAbort(2):
             return
@@ -428,6 +435,11 @@ class Player(xbmc.Player):
 
     def stop_playback(self):
         """Stop all playback. Check for external player for positionticks."""
+        try:
+            self._stop_segment_monitor()
+        except Exception as e:
+            LOG.warning("Failed to stop segment monitor thread: %s", e)
+
         if not self.played:
             return
 
@@ -735,6 +747,7 @@ class Player(xbmc.Player):
         """Monitor the skip dialog and handle user input or timeout."""
         LOG.debug("_monitor_skip_dialog: starting, end_time=%.1f", self._skip_end_time)
         monitor = xbmc.Monitor()
+        last_remaining = -1
 
         # Monitor loop - check for user input or end of segment
         while self.skip_dialog and not monitor.abortRequested():
@@ -758,7 +771,14 @@ class Player(xbmc.Player):
                         self._skip_end_time,
                     )
                     break
-            except Exception:
+
+                # Dynamic countdown update
+                remaining = int(self._skip_end_time - current_pos)
+                if remaining != last_remaining:
+                    self.skip_dialog.update_duration(remaining)
+                    last_remaining = remaining
+            except Exception as e:
+                LOG.debug("_monitor_skip_dialog error: %s", e)
                 break
 
             if monitor.waitForAbort(0.2):
@@ -771,3 +791,37 @@ class Player(xbmc.Player):
             except Exception:
                 pass
             self.skip_dialog = None
+
+    def _start_segment_monitor(self, item):
+        if not settings("mediaSegmentsEnabled.bool"):
+            return
+        self._stop_segment_monitor()
+        self._segment_thread_active = True
+        import threading
+        self._segment_thread = threading.Thread(
+            target=self._monitor_segments_loop,
+            args=(item,),
+            name="JellyfinSegmentMonitor"
+        )
+        self._segment_thread.daemon = True
+        self._segment_thread.start()
+        LOG.debug("Segment monitor thread started")
+
+    def _stop_segment_monitor(self):
+        self._segment_thread_active = False
+        self._segment_thread = None
+
+    def _monitor_segments_loop(self, item):
+        monitor = xbmc.Monitor()
+        while self._segment_thread_active and not monitor.abortRequested():
+            if not self.isPlaying():
+                break
+            try:
+                if self.isPlayingVideo() and not self.getTime() == 0:
+                    if not self.skip_dialog:
+                        current_pos = int(self.getTime())
+                        self.check_skip_segments(item, current_pos)
+            except Exception as e:
+                LOG.debug("Error in segment monitor loop: %s", e)
+            if monitor.waitForAbort(1):
+                break


### PR DESCRIPTION
The recently introduced segment skipping feature has two main issues:

1. **Trigger delay:** Segment checks currently run inside `report_playback`, which only executes on progress reports (every 10 seconds). Furthermore, the check runs before the player position is updated, causing the skip button to appear very late, or not at all unless manually forcing an OSD update (like pause/resume or seek).
2. **Static countdown:** Once the skip dialog is open, the duration countdown remains static and does not tick down (or every 10 seconds if long enough).

This PR addresses both:
- Spawns a lightweight background thread (`JellyfinSegmentMonitor`) during active video playback that polls and checks segments every 1 second.
- Adds an `update_duration` method to `SkipDialog` to dynamically update the window property and control label.
- Updates `_monitor_skip_dialog` to calculate remaining time and refresh the dialog once per second.
