### PR TITLE
Disable black in linting CI for now

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,6 +72,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: psf/black@stable
-        with:
-          version: "26.1.0"


### PR DESCRIPTION
This needs to be reworked into a proper CI solution.  As it sits now black never runs for the vast majority of contributors and causes linting to fail in code not even touched in the current PR.