### PR TITLE
fix(music): populate album duration on sync

### DIFF
--- a/jellyfin_kodi/objects/kodi/music.py
+++ b/jellyfin_kodi/objects/kodi/music.py
@@ -181,6 +181,11 @@ class Music(Kodi):
         else:
             self.cursor.execute(QU.update_album74, args)
 
+    def update_album_duration(self, *args):
+        # iAlbumDuration column was added to the album table in music db schema 80
+        if self.version_id >= 80:
+            self.cursor.execute(QU.update_album_duration, args)
+
     def get_album_artist(self, album_id, artists):
 
         try:

--- a/jellyfin_kodi/objects/kodi/queries_music.py
+++ b/jellyfin_kodi/objects/kodi/queries_music.py
@@ -231,6 +231,12 @@ update_album_obj = [
     "album",
     "{AlbumId}",
 ]
+update_album_duration = """
+UPDATE      album
+SET         iAlbumDuration = ?
+WHERE       idAlbum = ?
+"""
+update_album_duration_obj = ["{Runtime}", "{AlbumId}"]
 update_album_artist = """
 UPDATE      album
 SET         strArtists = ?

--- a/jellyfin_kodi/objects/music.py
+++ b/jellyfin_kodi/objects/music.py
@@ -158,6 +158,7 @@ class Music(KodiDb):
 
         obj["Rating"] = 0
         obj["LastScraped"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        obj["Runtime"] = (obj["Runtime"] or 0) / 10000000.0
         obj["Genres"] = obj["Genres"] or []
         obj["Genre"] = " / ".join(obj["Genres"])
         obj["Bio"] = API.get_overview(obj["Bio"])
@@ -182,6 +183,7 @@ class Music(KodiDb):
         self.artist_link(obj)
         self.artist_discography(obj)
         self.update_album(*values(obj, QU.update_album_obj))
+        self.update_album_duration(*values(obj, QU.update_album_duration_obj))
         self.add_genres(*values(obj, QU.add_genres_obj))
         self.artwork.add(obj["Artwork"], obj["AlbumId"], "album")
         self.item_ids.append(obj["Id"])

--- a/jellyfin_kodi/objects/obj_map.json
+++ b/jellyfin_kodi/objects/obj_map.json
@@ -190,6 +190,7 @@
 		"Year": "ProductionYear",
 		"Genres": "Genres",
 		"Bio": "Overview",
+		"Runtime": "RunTimeTicks,CumulativeRunTimeTicks",
 		"AlbumArtists": "AlbumArtists",
 		"Artists": "AlbumArtists:?$Name",
 		"ArtistItems": "ArtistItems",


### PR DESCRIPTION
When syncing a music library the album duration is omitted, this results in a zero value being shown in album information.

When Kodi is managing a music library it computes the album length from the individual track lengths, that approach could be replicated here but would be needless work for the client and would require the track/ album syncs to be correctly ordered.

Instead, the already available RunTimeTicks/ CumulativeRunTimeTicks can be used to populate the album duration in Kodi.

I got Claude to write the fix, it updates an album when it's played but a repair/ update of a library is required for all albums to be populated with the duration.