### PR TITLE
Honor StartIndex in remote Play commands so the selected track plays

### DIFF
--- a/jellyfin_kodi/monitor.py
+++ b/jellyfin_kodi/monitor.py
@@ -25,6 +25,22 @@ LOG = LazyLogger(__name__)
 #################################################################################################
 
 
+def order_from_start_index(items, item_ids, start_index):
+    """Order a remote Play command's items to match the requested ItemIds,
+    beginning at StartIndex.
+
+    ``get_items`` (``/Items?Ids=``) does not preserve the requested order, and a
+    remote Play command carries a ``StartIndex`` selecting which item to begin
+    with. Reorder the fetched items to the requested ``item_ids`` sequence and
+    drop everything before ``start_index`` so the chosen item plays first,
+    rather than always playing the first item that was fetched.
+    """
+    by_id = {item["Id"]: item for item in items}
+    ordered = [by_id[item_id] for item_id in item_ids if item_id in by_id]
+
+    return ordered[start_index:]
+
+
 class Monitor(xbmc.Monitor):
 
     servers = []
@@ -141,6 +157,12 @@ class Monitor(xbmc.Monitor):
         if method == "Play":
 
             items = server.jellyfin.get_items(data["ItemIds"])
+            # StartIndex is optional: music queues send it, but video casts omit
+            # it (they send StartPositionTicks / stream indices instead). Absent
+            # means start at the first item.
+            items["Items"] = order_from_start_index(
+                items["Items"], data["ItemIds"], data.get("StartIndex", 0)
+            )
 
             PlaylistWorker(
                 data.get("ServerId"),

--- a/tests/test_play_start_index.py
+++ b/tests/test_play_start_index.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import division, absolute_import, print_function, unicode_literals
+
+from jellyfin_kodi.monitor import order_from_start_index
+
+
+def _items(*ids):
+    return [{"Id": i, "Name": i} for i in ids]
+
+
+class TestOrderFromStartIndex:
+
+    def test_honors_start_index(self):
+        # Casting the second track must start playback on that track.
+        result = order_from_start_index(_items("a", "b", "c"), ["a", "b", "c"], 1)
+        assert [i["Id"] for i in result] == ["b", "c"]
+
+    def test_start_index_zero_keeps_all(self):
+        result = order_from_start_index(_items("a", "b", "c"), ["a", "b", "c"], 0)
+        assert [i["Id"] for i in result] == ["a", "b", "c"]
+
+    def test_reorders_to_requested_ids(self):
+        # get_items (/Items?Ids=) may return a different order than requested;
+        # StartIndex is an index into the requested ItemIds, so reorder first.
+        result = order_from_start_index(_items("c", "a", "b"), ["a", "b", "c"], 1)
+        assert [i["Id"] for i in result] == ["b", "c"]
+
+    def test_skips_items_the_server_did_not_return(self):
+        # "b" was requested but not returned by get_items.
+        result = order_from_start_index(_items("a", "c"), ["a", "b", "c"], 0)
+        assert [i["Id"] for i in result] == ["a", "c"]


### PR DESCRIPTION
This PR fixes a bug where casting a track in a playlist (e.g in an album) from another Jellyfin client to the Kodi Jellyfin client would always result in the first track in the playlist being played, rather than the selected track.

The websocket `Play` handler passed `StartPositionTicks` to the playlist worker but dropped the command's `StartIndex`, so casting any item in a list always started playback at the first item.

It also assumed `get_items()` (`/Items?Ids=`) returns items in the requested order. It does not: with no `SortBy`, the server's `BaseItemRepository.ApplyOrder` falls through to `query.OrderBy(e => e.SortName)` — the `Ids` are only a `WHERE ... IN` filter, so results come back in `SortName` order. When the queue order differs from `SortName` order (a shuffled queue, a playlist mixing albums, or a manually reordered queue), indexing `StartIndex` into the original `ItemIds` selects the wrong item.

This reorders the fetched items back to the requested `ItemIds` and begins playback at `StartIndex`, so the selected item plays. Added unit tests for the ordering helper.
