### PR TITLE
Report a track's start position as 0, not the stale player clock

### DIFF
--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -157,7 +157,7 @@ class Player(xbmc.Player):
                 LOG.info("Runtime is missing, Using Zero")
 
         try:
-            seektime = self.getTime()
+            self.getTime()  # confirm the player is ready; bail out if it isn't
         except Exception:  # at this point we should be playing and if not then bail out
             return
 
@@ -171,7 +171,12 @@ class Player(xbmc.Player):
         item.update(
             {
                 "File": file,
-                "CurrentPosition": item.get("CurrentPosition") or int(seektime),
+                # A fresh playback start is at 0 (or the resume point, which is
+                # already in item["CurrentPosition"]). Do NOT fall back to the live
+                # player clock here: on a track change getTime() still returns the
+                # previous track's position, which would report the new track as
+                # starting mid-way and stop clients resetting their progress bar.
+                "CurrentPosition": item.get("CurrentPosition") or 0,
                 "Muted": muted,
                 "Volume": volume,
                 "Server": Jellyfin(item["ServerId"]).get_client(),


### PR DESCRIPTION
On a track change, `onPlayBackStarted` derived the new track's start position from the live player clock (`getTime()`, via `set_item`). At that moment the clock can still return the *previous* track's position, so the new track was announced to the server at a non-zero position (observed: a freshly started track reported as beginning at 134s).

Two consequences:
- Clients paint the progress bar mid-track instead of resetting it to the start.
- The periodic reporter only sends once the position has advanced ≥30s from the last value, so it stays silent until the new track passes that stale mark.

A fresh start is 0 (or the resume point, which is already carried in `item["CurrentPosition"]`). This uses 0 as the fallback instead of the live clock. Genuine resumes are unaffected — they set `CurrentPosition` explicitly (`actions.py`, `item["PlaybackInfo"]["CurrentPosition"] = obj["Resume"]`). `getTime()` is kept only as the "is the player ready?" guard.
