### PR TITLE
Make SegmentChecker a daemon, abort-aware thread

### DIFF
--- a/jellyfin_kodi/segments.py
+++ b/jellyfin_kodi/segments.py
@@ -14,6 +14,7 @@ class SegmentChecker(threading.Thread):
         self.player = player
 
         threading.Thread.__init__(self)
+        self.daemon = True
 
     def stop(self):
         self.stop_thread = True
@@ -21,7 +22,9 @@ class SegmentChecker(threading.Thread):
     def run(self):
         LOG.info("--->[ segment checker ]")
 
-        while not self.stop_thread:
+        monitor = xbmc.Monitor()
+
+        while not self.stop_thread and not monitor.abortRequested():
             if self.player.isPlaying() and settings("mediaSegmentsEnabled.bool"):
                 try:
                     current_file = self.player.get_playing_file()
@@ -35,6 +38,7 @@ class SegmentChecker(threading.Thread):
                 except Exception as e:
                     LOG.exception("Error in segment checker loop: %s", e)
 
-            xbmc.sleep(1000)
+            if monitor.waitForAbort(1):
+                break
 
         LOG.info("---<[ segment checker ]")


### PR DESCRIPTION
# Make SegmentChecker a daemon, abort-aware thread (fixes indefinite shutdown hang)

## Summary

The media-segment checker (`segments.py`) can make Kodi **hang forever on
shutdown** if you quit Kodi while something is still playing. This PR makes
`SegmentChecker` a daemon thread that also stops as soon as Kodi signals
shutdown, so it can no longer block the exit.

## The bug

`SegmentChecker` is a plain `threading.Thread`, started on playback
(`Player.onPlayBackStarted` → `_reset_segment_checker`). Its loop only exits
when `stop()` is called — and `stop()` is only called from
`onPlayBackStopped` / `onPlayBackEnded`. If Kodi is quit **while media is still
playing**, those callbacks never fire, so `stop()` is never called and the
thread keeps looping.

Because the thread is **not** a daemon, CPython's `threading._shutdown()`
blocks joining it during interpreter finalization, which in turn blocks Kodi:

```
main thread:
  CApplication::Cleanup()
    CScriptInvocationManager::Uninitialize()
      CLanguageInvokerThread::stop()
        std::thread::join()        <-- no timeout here; waits forever
```

There is no timeout anywhere in that chain, so Kodi hangs indefinitely and
never reaches the rest of teardown, such as unloading the skin or releasing
the display.

### How it was diagnosed

Reproduced on a standalone GBM install (Kodi 22.0, flatpak) by quitting Kodi
during playback.

**1. Kodi's log** — teardown starts, Kodi's own 5-second script kill fires for
the Jellyfin service, then output stops entirely and shutdown never completes:

```
15:57:51  Stopping the application...
15:58:01  CPythonInvoker(2, .../plugin.video.jellyfin/service.py):
          script didn't stop in 5 seconds - let's kill it
          <no further log output — shutdown stalled here>
```

**2. Main-thread stack** (`gdb`, with `set sysroot /proc/<pid>/root` so symbols
resolve inside the flatpak mount namespace) — blocked in an unbounded
`std::thread::join()` during script-manager teardown:

```
#3  __pthread_clockjoin_ex
#4  std::thread::join()
#5  CThread::StopThread(bool)
#6  CLanguageInvokerThread::stop(bool)
#7  CScriptInvocationManager::Uninitialize()
#8  CApplication::Cleanup()
#9  CApplication::Run()
#10 main()
```

**3. The thread it was waiting on** was parked in a blocking sleep:

```
#3  nanosleep
#4  XBMCAddon::xbmc::sleep(long)
```

**4. `py-spy dump`** identified the live Python thread — a plain
`threading.Thread` (not one of Kodi's tracked script threads), running in
`segments.py`:

```
Thread (active): "Thread-147"
    run (jellyfin_kodi/segments.py:38)      # this line was `xbmc.sleep(1000)`
    _bootstrap_inner (threading.py:1044)
    _bootstrap (threading.py:1015)
```

**Putting it together:** the `SegmentChecker` thread sits in `xbmc.sleep(1000)`
(→ `nanosleep`) and, being non-daemon, is joined by CPython's
`threading._shutdown()` during interpreter finalization — which is what Kodi's
`CLanguageInvokerThread::stop()` → `std::thread::join()` then blocks on, with no
timeout. Kodi's 5-second force-kill can't help here: it injects an async
exception into interpreter *bytecode*, so it can't interrupt a thread already
down in a C-level `nanosleep`, and it doesn't act on a plain `threading.Thread`
at all.

## The fix

```python
# __init__
threading.Thread.__init__(self)
self.daemon = True

# run()
monitor = xbmc.Monitor()
while not self.stop_thread and not monitor.abortRequested():
    ...
    if monitor.waitForAbort(1):    # was: xbmc.sleep(1000)
        break
```

- `daemon=True` — a daemon thread is never joined at interpreter shutdown, so
  it can no longer block Kodi's exit under any circumstances.
- `monitor.abortRequested()` / `waitForAbort(1)` — the loop now exits promptly
  when Kodi signals shutdown, even if `stop()` is never called, and wakes
  instantly instead of always sleeping a full second.

## Why this is safe

- **While you're watching, nothing changes.** `waitForAbort(1)` waits one
  second and checks for skip points exactly like the old `xbmc.sleep(1000)`
  did — same behaviour, same timing.
- The only new behaviour is: **when Kodi is closing, this background thread
  stops right away** instead of running on.
- Stopping it early can't break or lose anything. This thread doesn't save
  files, write settings, or hold any locks — it just reads the playback
  position and, on an intro/credits segment, seeks or shows the skip prompt.
  That's throwaway per-video info Kodi is discarding as it closes anyway.
- It stops **between** checks, while it's idle waiting — not in the middle of
  doing anything — so there's no half-finished work.
- `daemon=True` is a safety belt: even in an unexpected situation, Kodi's
  shutdown can no longer get stuck on this thread.

Net effect: Kodi finishes shutting down normally instead of hanging.

## Testing

Validated on real hardware (Kodi 22.0 flatpak, standalone GBM):

- **Before:** quitting Kodi during playback hung shutdown indefinitely.
- **After:** 3/3 quit-during-playback exits shut down cleanly in ~3–5 seconds.
