### PR TITLE
Keep server order as collection default, honor sort titles

### DIFF
--- a/jellyfin_kodi/entrypoint/default.py
+++ b/jellyfin_kodi/entrypoint/default.py
@@ -768,12 +768,15 @@ def browse(media, view_id=None, folder=None, server_id=None, api_client=None):
         xbmcplugin.addSortMethod(PROCESS_HANDLE, xbmcplugin.SORT_METHOD_VIDEO_RATING)
         xbmcplugin.addSortMethod(PROCESS_HANDLE, xbmcplugin.SORT_METHOD_VIDEO_RUNTIME)
     elif media in ("boxset", "library"):
+        xbmcplugin.addSortMethod(PROCESS_HANDLE, xbmcplugin.SORT_METHOD_UNSORTED)
         xbmcplugin.addSortMethod(PROCESS_HANDLE, xbmcplugin.SORT_METHOD_DATE)
         xbmcplugin.addSortMethod(PROCESS_HANDLE, xbmcplugin.SORT_METHOD_VIDEO_YEAR)
         xbmcplugin.addSortMethod(
             PROCESS_HANDLE, xbmcplugin.SORT_METHOD_VIDEO_ORIGINAL_TITLE
         )
-        xbmcplugin.addSortMethod(PROCESS_HANDLE, xbmcplugin.SORT_METHOD_VIDEO_TITLE)
+        xbmcplugin.addSortMethod(
+            PROCESS_HANDLE, xbmcplugin.SORT_METHOD_VIDEO_SORT_TITLE
+        )
 
     xbmcplugin.setContent(PROCESS_HANDLE, content_type)
     xbmcplugin.endOfDirectory(PROCESS_HANDLE)


### PR DESCRIPTION
#### What
Follow-up to #1134, which added sort methods to collection / library-folder listings (first shipped in v2.1.0). Registering them changed more than intended.

These listings are requested from the server with `SortBy=SortName`, and before #1134 Kodi showed them exactly as delivered, since no sort methods were registered. Now Kodi actively sorts the container by the first registered method (date), so the SortName order, the one that respects user-configured sort titles in Jellyfin, is gone. And because "unsorted" isn't registered, there's no way back to it from the GUI.

Sorting by title doesn't help: `SORT_METHOD_VIDEO_TITLE` is Kodi's plain visible-title sort. The listitems built by this addon already carry `sorttitle`, but nothing exposed it.

#### Fix
Register `SORT_METHOD_UNSORTED` first. The first registered method is the container default, and unsorted keeps the incoming SortName order, so the default display matches what it was before #1134 while the sort options #1134 added stay available.

Replace `SORT_METHOD_VIDEO_TITLE` with `SORT_METHOD_VIDEO_SORT_TITLE`. It shows up under the same "Title" label in Kodi's sort chooser, but honors `sorttitle`, falls back to the plain title for items without one (`SortUtils::BySortTitle`), and respects the "Ignore articles when sorting" setting. This is also what Kodi's own video library windows register for their title sort.

Side benefit: users who already picked "Title" on v2.1.0 have a saved view state pointing at the plain-title sort. After this change that method no longer matches anything registered, so they fall back to the unsorted default instead of staying stuck with a sort that ignores their sort titles.

#### Issues
Fixes the regression reported downstream at https://github.com/pannal/CoreELEC/issues/77 (Jellyfin sort titles ignored in collection / "Other" listings after updating to v2.1.0).
