### PR TITLE
fix(player): stop the segment checker so Kodi can shut down

### DIFF
--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -435,10 +435,12 @@ class Player(xbmc.Player):
 
     def stop_playback(self):
         """Stop all playback. Check for external player for positionticks."""
+        # Playback we never tracked (live TV, another addon's file) still
+        # started a segment checker, so tear down state before the guard.
+        self._reset_state()
+
         if not self.played:
             return
-
-        self._reset_state()
 
         LOG.info("Played info: %s", self.played)
 
@@ -779,6 +781,7 @@ class Player(xbmc.Player):
     def _reset_segment_checker(self, restart=False):
         if self.segment_checker:
             self.segment_checker.stop()
+            self.segment_checker = None
 
         if restart:
             self.segment_checker = SegmentChecker(player=self)

--- a/jellyfin_kodi/segments.py
+++ b/jellyfin_kodi/segments.py
@@ -20,6 +20,7 @@ class SegmentChecker(threading.Thread):
 
     def run(self):
         LOG.info("--->[ segment checker ]")
+        monitor = xbmc.Monitor()
 
         while not self.stop_thread:
             if self.player.isPlaying() and settings("mediaSegmentsEnabled.bool"):
@@ -35,6 +36,7 @@ class SegmentChecker(threading.Thread):
                 except Exception as e:
                     LOG.exception("Error in segment checker loop: %s", e)
 
-            xbmc.sleep(1000)
+            if monitor.waitForAbort(1):
+                break
 
         LOG.info("---<[ segment checker ]")


### PR DESCRIPTION
After playing a video the addon doesn't track, Kodi hangs forever on exit. The GUI closes, but kodi.bin never terminates and it has to be killed.

The log shows the addon's service script itself exiting cleanly, and then Kodi blocking on a leftover thread:

Partially addresses #1056, this is one instance of the hang-on-exit issue predicted here.

Figured this out with a bot and below is its detailed explanation and proposed fix.

```
JELLYFIN.__main__ -> INFO::service.py:80 --<[ service ]
CPythonInvoker(3, .../plugin.video.jellyfin/service.py): script successfully run
CPythonInvoker(3, .../plugin.video.jellyfin/service.py): waiting on thread 139670283404992
CPythonInvoker(3, .../plugin.video.jellyfin/service.py): script didn't stop in 5 seconds - let's kill it
   <hangs here indefinitely>
```

Attaching py-spy to the hung process identifies the thread Kodi is waiting on:

```
Thread 929862 (active)
    run (jellyfin_kodi/segments.py:38)
    _bootstrap_inner (threading.py:1082)
```

That's `SegmentChecker`, still spinning long after playback ended.

### Root cause

Two defects in `SegmentChecker`, both introduced in #1116, combine:

**1. The thread never observes Kodi's abort.** `SegmentChecker.run()` loops on `while not self.stop_thread` and idles with `xbmc.sleep(1000)`. It never checks `abortRequested`, so it has no way to exit on shutdown unless somebody explicitly calls `stop()`. Every other long-lived thread in the addon (`Library.run`, `monitor.Listener.run`, `Player._monitor_skip_dialog`) waits on `waitForAbort` and terminates by itself.

**2. Nobody calls `stop()` for untracked playback.** A checker is started on every playback start via `_reset_state(restart=True)`, but is only stopped from `stop_playback()` — which begins with:

```python
def stop_playback(self):
    if not self.played:
        return
    self._reset_state()
```

`self.played` is only populated for items the addon reports on. Live TV never enters it, so stopping a live channel returns early, `_reset_state()` never runs, and that playback's checker is orphaned. The log shows it plainly — two checkers started, only the first ever exited (it was stopped by the second one's start):

```
12:31:38.515 T:926047  --->[ segment checker ]
12:32:18.426 T:929862  --->[ segment checker ]
12:32:18.693 T:926047  ---<[ segment checker ]      <-- the orphan (929862) never exits
```

Together these mean an orphaned checker survives to shutdown, and once there, it cannot be killed: Kodi's `CPythonInvoker` raises an async `SystemExit` into the script's **main** thread, which has already returned. The leftover worker thread never sees it, and the invoker's join never completes.

### The fix

- `segments.py`: idle on `xbmc.Monitor().waitForAbort(1)` and break on abort, instead of `xbmc.sleep(1000)`. The thread now always dies on Kodi shutdown, regardless of who forgot to stop it. This alone fixes the hang.
- `player.py`: move `_reset_state()` above the `if not self.played` guard in `stop_playback()`, so untracked playback (live TV, another addon's file) also tears down its checker.
- `player.py`: clear `self.segment_checker` after stopping it, so the attribute doesn't keep pointing at a dead thread.

### Testing

Kodi 21.3, Debian, Python 3.14. Reproduced and verified:

- **Before:** play a live TV channel, stop it, quit Kodi → `kodi.bin` hangs indefinitely; `SIGTERM` has no effect.
- **After:** stopping the channel now logs `---<[ segment checker ]` (previously it logged nothing and the thread leaked). Quitting Kodi *while a checker is still running* exits cleanly in a couple of seconds, with no `script didn't stop in 5 seconds` for `plugin.video.jellyfin`. py-spy confirms no `segments.py` thread survives playback stop.
- Existing test suite passes; flake8 clean.