### PR TITLE
fix(helper): survive the add-on being unregistered mid-run

### DIFF
--- a/jellyfin_kodi/client.py
+++ b/jellyfin_kodi/client.py
@@ -6,11 +6,10 @@ from __future__ import division, absolute_import, print_function, unicode_litera
 import os
 
 import xbmc
-import xbmcaddon
 import xbmcvfs
 
-from .helper import translate, window, settings, addon_id, dialog, LazyLogger
-from .helper.utils import create_id, translate_path
+from .helper import translate, window, settings, dialog, LazyLogger
+from .helper.utils import create_id, get_addon, translate_path
 
 ##################################################################################################
 
@@ -21,11 +20,15 @@ LOG = LazyLogger(__name__)
 
 def get_addon_name():
     """Used for logging."""
-    return xbmcaddon.Addon(addon_id()).getAddonInfo("name").upper()
+    addon = get_addon()
+
+    return addon.getAddonInfo("name").upper() if addon else "JELLYFIN"
 
 
 def get_version():
-    return xbmcaddon.Addon(addon_id()).getAddonInfo("version")
+    addon = get_addon()
+
+    return addon.getAddonInfo("version") if addon else ""
 
 
 def get_platform():

--- a/jellyfin_kodi/helper/translate.py
+++ b/jellyfin_kodi/helper/translate.py
@@ -20,7 +20,13 @@ def translate(string):
     if not isinstance(string, int):
         string = STRINGS[string]
 
-    result = xbmcaddon.Addon("plugin.video.jellyfin").getLocalizedString(string)
+    try:
+        result = xbmcaddon.Addon("plugin.video.jellyfin").getLocalizedString(string)
+    except RuntimeError:
+        # Add-on briefly unregistered while it is installed over the running
+        # copy. Fall through to Kodi's own strings rather than take down the
+        # thread that wanted the text.
+        result = ""
 
     if not result:
         result = xbmc.getLocalizedString(string)

--- a/jellyfin_kodi/helper/utils.py
+++ b/jellyfin_kodi/helper/utils.py
@@ -33,6 +33,20 @@ def addon_id():
     return "plugin.video.jellyfin"
 
 
+def get_addon():
+    """Kodi unregisters the add-on for a moment while it is installed over the
+    running copy, and xbmcaddon.Addon() raises RuntimeError('Unknown addon id')
+    for the whole of that window. settings() is reached from the log handler on
+    every record, so an uncaught one kills whichever thread happened to log --
+    including the service's own shutdown path, which then misses Kodi's five
+    second deadline and gets killed with its threads still running.
+    """
+    try:
+        return xbmcaddon.Addon(addon_id())
+    except RuntimeError:
+        return None
+
+
 def kodi_version():
     # Kodistubs returns empty string, causing Python 3 tests to choke on int()
     # TODO: Make Kodistubs version configurable for testing purposes
@@ -81,7 +95,13 @@ def settings(setting, value=None):
     """Get or add add-on settings.
     getSetting returns unicode object.
     """
-    addon = xbmcaddon.Addon(addon_id())
+    addon = get_addon()
+
+    if addon is None:
+        # Unregistered, see get_addon(). "" is what Kodi returns for a setting
+        # that was never set, so readers already cope with it; a write is lost
+        # either way, because the settings file is being replaced.
+        return ""
 
     if value is not None:
         if setting.endswith(".bool"):


### PR DESCRIPTION
Installing the add-on over a running copy leaves it unregistered for a moment. For the whole of that window, `xbmcaddon.Addon()` raises `RuntimeError: Unknown addon id 'plugin.video.jellyfin'`. The toast notification error on upgrading the add-on is a symptom of this.

On Linux, Kodi hangs until killed, on Android Kodi appears to exit but has to be force stopped for a successful restart.

Fixes: https://github.com/jellyfin/jellyfin-kodi/issues/324

I figured this out with a bot and below is a detailed explanation from it.

The version being installed makes no difference. `CAddonInstallJob::DoWork()` calls `CAddonMgr::UnloadAddon()` *unconditionally* before replacing the files, and `m_isUpdate` is set from `GetAddon(id, dummy, OnlyEnabled::CHOICE_NO)` — "is this add-on already installed" — with no version comparison anywhere in the sequence (`UnloadAddon` → `Install` → `LoadAddon`, which publishes `ReInstalled`). So reinstalling the same version over itself (a rebuilt zip — how this was first hit) and a routine repo upgrade to a newer version open exactly the same window. Since repo auto-updates fire on every published version bump, this sits on the path of every ordinary add-on update, not just a manual reinstall.

Two things make that window dangerous rather than merely awkward:

1. `CServiceAddonManager::Stop()` calls `CScriptInvocationManager::Stop(id)` with the default `wait = false`, so Kodi asks the service to stop and **does not wait for it**. The outgoing instance is still running while the add-on is being unregistered and re-registered underneath it.
2. `settings()` (`helper/utils.py`) constructs an `Addon` on every call, and it is reached from `LogHandler.emit()` via `_get_log_level()` — i.e. **on every log record**. `logging.Handler.handle()` does not swallow exceptions from `emit()`, so the `RuntimeError` escapes out of any `LOG.*` call at all.

The result is that *logging itself raises*, and every thread that happens to log during the window dies. Observed on Kodi 21.3 — the monitor listener (`monitor.py:411`), the library thread (`library.py:126`) and, worst, `entrypoint/service.py:510 shutdown()`. All five tracebacks bottom out in the same three frames:

```
  File "jellyfin_kodi/helper/loghandler.py", line 58, in emit
  File "jellyfin_kodi/helper/loghandler.py", line 84, in _get_log_level
  File "jellyfin_kodi/helper/utils.py", line 84, in settings
RuntimeError: Unknown addon id 'plugin.video.jellyfin'.
```

With `shutdown()` dead, the service never finishes stopping, so Kodi kills it:

```
CPythonInvoker(3, .../plugin.video.jellyfin/service.py): script didn't stop in 5 seconds - let's kill it
```

Kodi can kill the *invoker*, but not the add-on's own `threading.Thread` objects. They survive, a fresh service instance starts alongside them, and from then on those orphaned threads block Kodi's own shutdown — the process reaches `Unloaded skin` and then hangs indefinitely, still logging `KeepAlive` events minutes later, needing `SIGKILL`.

So a single unguarded `Addon()` lookup on the logging path turns a sub-second window into a Kodi that will not exit for the rest of its life.

This is the root cause of **#324**, open since June 2020 and labelled `help wanted`. The log in that report ends in exactly these frames (`emit` → `_get_log_level` → `settings` → `RuntimeError`), reached from `LOG.info()` through the Python `logging` internals, which is also direct evidence that `Handler.handle()` re-raises whatever `emit()` throws. The issue was read at the time as a threading problem — *"could not get it for it to cleanup all the threads. Think if we ever get around to cleaning up the threading in the addon this would get resolved"* — but the threads are not failing to clean up, they are being **killed mid-cleanup** by the exception coming out of their own log calls, and `shutdown()` dies the same way, so nothing is left to join them. Uninstall (as in #324), reinstall and upgrade all unregister the add-on and hit the identical window.

## Changes

Guard the lookup and degrade instead of raising. New `get_addon()` helper in `helper/utils.py` returns `None` when the add-on is unregistered; the three call sites reachable from long-running threads fall back:

- **`settings()`** returns `""`. That is exactly what Kodi returns for a setting that was never set, so the 143 call sites already cope with it — and `int("")` lands on the `except ValueError` fallback already present in `_get_log_level()`, so logging keeps working through the window.
- **`translate()`** falls through to `xbmc.getLocalizedString()`, the fallback the function already had for an empty result. Guarded locally rather than via `get_addon()`, because `utils` imports `translate` and the reverse import would be circular.
- **`client.get_addon_name()` / `get_version()`** fall back to `"JELLYFIN"` and `""`.

The UI-only lookups (`entrypoint/context.py`, `dialogs/context.py`, `objects/actions.py`, `player.py`, `connect.py`) are left alone: they run from user-initiated actions, not from the background threads that have to survive and complete a shutdown.

## Testing

First hit in the wild by installing a rebuilt zip of the **same version** (`2.1.0+py3` over `2.1.0+py3`) while Kodi was running: five tracebacks, the five second kill, then a Kodi that reached `Unloaded skin` and never exited — still logging `KeepAlive` events three minutes later, killed with `SIGKILL`.

Reduced to a repeatable case by **disabling** the add-on, which unregisters it exactly the way the install does (`CAddonMgr::GetAddon(..., OnlyEnabled::CHOICE_YES)` fails, so the constructor throws) without needing to rebuild and reinstall a zip each time. Kodi 21.3, live server.

| | Before | After |
|---|---|---|
| `Unknown addon id` errors | 11 | 22 |
| Python tracebacks | 5 | **0** |
| `didn't stop in 5 seconds` kills | 1 | **0** |
| Kodi shutdown afterwards | hangs indefinitely (SIGKILL) | **exits cleanly in 9s** |

After the fix the threads survive and log their own clean exits instead of dying mid-record — `monitor.py:411 ---<[ listener ]`, `library.py:126 ---<[ library ]`, and `service.py:510 ---<[ EXITING ]`, the frame that used to throw.

`flake8` clean on the changed files; the full suite passes (196 tests on this base).

## Issues

- **The `EXCEPTION: Unknown addon id` log lines remain** (and the count goes *up*, 11 → 22). Kodi logs those from the C++ binding layer *before* the Python exception is raised, so a `try/except` cannot silence them. They are now harmless, and there are more of them only because the threads survive to keep logging instead of dying at the first record.

- **"Why not just cache the `Addon` object instead?"** - a fair question, and the honest answer is that caching is a reasonable refactor, just not this PR.

Catching `RuntimeError` from `xbmcaddon.Addon()` is itself an established pattern in official-repo add-ons (`plugin.video.youtube` uses it four times, `plugin.program.iptv.merge`) — though there it probes whether a *different* add-on is installed, not whether one's own is still registered. For their **own** add-on, most cache it once at import (`service.xbmc.versioncheck`, `plugin.video.iplayerwww` all do `ADDON = xbmcaddon.Addon()` at module level). Those add-ons never throw, which is why they have never needed this fix. jellyfin-kodi is unusual in reconstructing an `Addon` on *every* `settings()` call - 143 call sites, one of them on the logging path - and that is what turns a sub-second window into dead threads.

Caching would work: construction is the only throw point (`getSetting()` reads through the stored `pAddon`), and a cached wrapper does *not* go stale on settings changes — `Addon::Addon()` calls `AddToUpdateableAddons(pAddon)`, and `CAddonMgr::ReloadSettings()` refreshes exactly that list, which is machinery that exists to keep long-lived wrappers current. It would also drop the log noise above and 143 redundant constructions.

It is deliberately out of scope here. This PR fixes a shutdown hang, and the guard cannot regress anything — it only changes behaviour on a path that currently *raises*. Converting the settings layer to a cached object changes what every read observes across a reinstall (the cached wrapper keeps the *old* `AddonPtr` after `LoadAddon()` swaps in a new one), and that deserves to be judged on its own merits rather than smuggled in behind a hang fix.

- **Unrelated, still open:** the service also misses the 5-second deadline on a *normal* Kodi shutdown, because its threads are simply slow to wind down. That is a separate problem (same class as the segment-checker shutdown fix) and is not addressed here. Kodi now exits anyway rather than hanging, because no threads are orphaned.

- `flake8 jellyfin_kodi/` also reports two pre-existing `I201` import-order warnings in `jellyfin_kodi/segments.py`, untouched by this branch.
