### PR TITLE
Ignore unexpected database filenames

### DIFF
--- a/jellyfin_kodi/database/__init__.py
+++ b/jellyfin_kodi/database/__init__.py
@@ -116,16 +116,11 @@ class Database(object):
         database = types[database]
         dirs, files = xbmcvfs.listdir(databases)
         target = {"db_file": "", "version": 0}
+        database_pattern = re.compile(r"{}(\d+)\.db".format(re.escape(database)))
 
         for db_file in reversed(files):
-            if (
-                db_file.startswith(database)
-                and not db_file.endswith("-wal")
-                and not db_file.endswith("-shm")
-                and not db_file.endswith("db-journal")
-            ):
-
-                version_string = re.search("{}(.*).db".format(database), db_file)
+            version_string = database_pattern.fullmatch(db_file)
+            if version_string:
                 version = int(version_string.group(1))
 
                 if version > target["version"]:

--- a/tests/test_database_discovery.py
+++ b/tests/test_database_discovery.py
@@ -1,0 +1,45 @@
+import sqlite3
+from types import SimpleNamespace
+
+from jellyfin_kodi import database as database_module
+from jellyfin_kodi.database import Database
+
+
+def test_database_discovery_ignores_unexpected_files_and_opens_highest_version(
+    monkeypatch, tmp_path
+):
+    for version in (130, 131):
+        path = tmp_path / "MyVideos{}.db".format(version)
+        with sqlite3.connect(path) as connection:
+            connection.execute("CREATE TABLE database_version (version INTEGER)")
+            connection.execute("INSERT INTO database_version VALUES (?)", (version,))
+
+    files = [
+        "MyVideos131.db",
+        "MyVideos132 - Copy.db",
+        "MyVideos999.db-wal",
+        "MyVideos998.db-shm",
+        "MyVideos997.db-journal",
+        "MyVideos130.db",
+    ]
+    database_prefix = "special://database/"
+
+    def translate_database_path(path):
+        if path.startswith(database_prefix):
+            return str(tmp_path / path[len(database_prefix) :])
+        return path
+
+    monkeypatch.setattr(database_module.xbmcvfs, "listdir", lambda path: ([], files))
+    monkeypatch.setattr(database_module, "translate_path", translate_database_path)
+    monkeypatch.setattr(
+        database_module.obj,
+        "Objects",
+        lambda: SimpleNamespace(objects={}),
+    )
+
+    with Database("video") as database:
+        version = database.cursor.execute(
+            "SELECT version FROM database_version"
+        ).fetchone()
+
+    assert version == (131,)


### PR DESCRIPTION
## Summary

- only consider exact `<database><version>.db` filenames during Kodi database discovery
- ignore copied databases and SQLite sidecar files instead of trying to parse their suffixes as version numbers
- add a regression test that opens the highest valid SQLite database while unexpected filenames are present

## Root cause

Database discovery captured everything between the database prefix and `.db`, then passed it to `int()`. A copied file such as `MyVideos121 - Copy.db` therefore raised `ValueError` and stopped add-on startup.

## User impact

Unexpectedly named database files no longer prevent Jellyfin for Kodi from starting and discovering the active Kodi database. The existing behavior of selecting the highest valid database version is preserved.

## Testing

- `python -m pytest -q` — 197 passed on Python 3.12
- `python -m pytest -q` — 197 passed on Python 3.14
- `black --check .`
- CI fatal-error flake8 gate
- full flake8 on the changed implementation and test
- `git diff --check`
- add-on ZIP build and archive integrity check

## Code assistance

Developed with assistance from OpenAI Codex. The final patch and regression coverage were reviewed and verified with the checks listed above.

Fixes #967
