### PR TITLE
Write playlist and node XML as UTF-8

### DIFF
--- a/jellyfin_kodi/views.py
+++ b/jellyfin_kodi/views.py
@@ -281,7 +281,7 @@ class Views(object):
             etree.SubElement(rule, "value").text = view["Tag"]
 
         tree = etree.ElementTree(xml)
-        tree.write(file)
+        tree.write(file, encoding="utf-8")
 
     def add_nodes(self, path, view, mixed=False):
         """Create or update the video node file."""
@@ -355,7 +355,7 @@ class Views(object):
             self.node_all(xml)
 
         tree = etree.ElementTree(xml)
-        tree.write(file)
+        tree.write(file, encoding="utf-8")
 
     def node_root(self, root, index):
         """Create the root element"""
@@ -397,7 +397,7 @@ class Views(object):
         )
 
         tree = etree.ElementTree(xml)
-        tree.write(file)
+        tree.write(file, encoding="utf-8")
 
     def node(self, folder, view):
 
@@ -461,7 +461,7 @@ class Views(object):
 
         getattr(self, "node_" + node)(xml)  # get node function based on node type
         tree = etree.ElementTree(xml)
-        tree.write(file)
+        tree.write(file, encoding="utf-8")
 
     def add_dynamic_node(self, index, file, view, node, name, path):
 
@@ -487,7 +487,7 @@ class Views(object):
 
         getattr(self, "node_" + node)(xml, path)
         tree = etree.ElementTree(xml)
-        tree.write(file)
+        tree.write(file, encoding="utf-8")
 
     def node_all(self, root):
 

--- a/jellyfin_kodi/views.py
+++ b/jellyfin_kodi/views.py
@@ -279,7 +279,7 @@ class Views(object):
             etree.SubElement(rule, "value").text = view["Tag"]
 
         tree = etree.ElementTree(xml)
-        tree.write(file)
+        tree.write(file, encoding="utf-8", xml_declaration=True)
 
     def add_nodes(self, path, view, mixed=False):
         """Create or update the video node file."""
@@ -353,7 +353,7 @@ class Views(object):
             self.node_all(xml)
 
         tree = etree.ElementTree(xml)
-        tree.write(file)
+        tree.write(file, encoding="utf-8", xml_declaration=True)
 
     def node_root(self, root, index):
         """Create the root element"""
@@ -395,7 +395,7 @@ class Views(object):
         )
 
         tree = etree.ElementTree(xml)
-        tree.write(file)
+        tree.write(file, encoding="utf-8", xml_declaration=True)
 
     def node(self, folder, view):
 
@@ -459,7 +459,7 @@ class Views(object):
 
         getattr(self, "node_" + node)(xml)  # get node function based on node type
         tree = etree.ElementTree(xml)
-        tree.write(file)
+        tree.write(file, encoding="utf-8", xml_declaration=True)
 
     def add_dynamic_node(self, index, file, view, node, name, path):
 
@@ -485,7 +485,7 @@ class Views(object):
 
         getattr(self, "node_" + node)(xml, path)
         tree = etree.ElementTree(xml)
-        tree.write(file)
+        tree.write(file, encoding="utf-8", xml_declaration=True)
 
     def node_all(self, root):
 

--- a/tests/test_views_playlist.py
+++ b/tests/test_views_playlist.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import division, absolute_import, print_function, unicode_literals
+
+import os
+import xml.etree.ElementTree as etree
+
+from jellyfin_kodi.views import Views
+
+
+def write_playlist(directory, tag):
+    view = {"Media": "movies", "Id": "abc123", "Name": tag, "Tag": tag}
+    # add_playlist() never touches `self`, so it can be called unbound.
+    Views.add_playlist(None, str(directory), view)
+
+    return os.path.join(str(directory), "jellyfinmoviesabc123.xsp")
+
+
+def test_add_playlist_writes_non_ascii_tag_as_utf8(tmp_path):
+    """A non-ASCII library name must be written as literal UTF-8.
+
+    ElementTree.write() defaults to us-ascii, which escapes non-ASCII
+    characters as numeric character references. Kodi does not decode those
+    inside a smart playlist rule value, so it compares the literal string
+    (e.g. "Pel&#237;culas") against the tag name and matches nothing.
+    """
+    playlist = write_playlist(tmp_path, "Películas")
+
+    with open(playlist, "rb") as f:
+        raw = f.read()
+
+    assert "Películas".encode("utf-8") in raw
+    assert b"&#" not in raw
+
+
+def test_add_playlist_does_not_duplicate_existing_rule(tmp_path):
+    """The playlist is rewritten on every view refresh, so re-running must
+    reuse the existing rule rather than appending a second one."""
+    playlist = write_playlist(tmp_path, "Películas")
+    write_playlist(tmp_path, "Películas")
+
+    root = etree.parse(playlist).getroot()
+
+    assert [element.text for element in root.findall(".//value")] == ["Películas"]


### PR DESCRIPTION
Libraries with non-ASCII characters in their name end up with an empty playlist in Kodi. For example, my `Séries` library showed nothing, while `Films` in the same install worked fine.

`ElementTree.write()` defaults to `us-ascii` without an XML declaration, so the tag is written to the `.xsp` as `S&#233;ries`. Kodi then loads smart playlists through TinyXML's stream parser ([SmartPlayList.cpp#L1236](https://github.com/xbmc/xbmc/blob/Omega/xbmc/playlists/SmartPlayList.cpp#L1236)), and without a UTF-8 declaration TinyXML doesn't decode `&#233;` as a UTF-8 sequence, so nothing matches (when it tries to compare it with the tag in the Kodi video database).

Kodi itself adds a UTF-8 declaration when saving smart playlists ([SmartPlayList.cpp#L1407-L1409](https://github.com/xbmc/xbmc/blob/Omega/xbmc/playlists/SmartPlayList.cpp#L1407-L1409)), so we are doing the same with this change.

(Re) Tested on my CoreELEC 21.3 with a 108-show library: 0 items before, 108 after.