### PR TITLE
Fix hang on sigterm

### DIFF
--- a/jellyfin_kodi/segments.py
+++ b/jellyfin_kodi/segments.py
@@ -20,8 +20,9 @@ class SegmentChecker(threading.Thread):
 
     def run(self):
         LOG.info("--->[ segment checker ]")
+        monitor = xbmc.Monitor()
 
-        while not self.stop_thread:
+        while not self.stop_thread and not monitor.abortRequested():
             if self.player.isPlaying() and settings("mediaSegmentsEnabled.bool"):
                 try:
                     current_file = self.player.get_playing_file()


### PR DESCRIPTION
https://github.com/jellyfin/jellyfin-kodi/pull/1162 and https://github.com/jellyfin/jellyfin-kodi/pull/1159 attempt to fix a hang when closing kodi with the addon installed.

This pull request attempts to do it while only adding one line and editing one line.

Here is an explanation of the cause written by the agent that narrowed it down:

Cause: The Jellyfin addon starts a SegmentChecker Python thread whenever playback begins (it checks 
media-segment skip positions once per second). Its loop is while not self.stop_thread: … xbmc.sleep(1000) — it only exits when stop() is called, which happens via the player's onPlayBackStopped/onPlayBackEnded callbacks.
 
If Kodi is quit while something is still playing, those callbacks never fire — so stop() is never called and the 
thread keeps looping forever. During shutdown, Kodi waits for leftover addon threads to terminate before finalizing the Python interpreter, and its main thread blocks joining the script invoker (std::thread::join(), no timeout). Kodi's 5-second force-kill fallback can't help: it injects an async exception into Python bytecode, which can't interrupt a thread sleeping inside xbmc.sleep (a C-level nanosleep).
 
Result: kodi.bin never exits after playback — SIGTERM is ignored and only SIGKILL works.
 
Fix: make the loop abort-aware (and not monitor.abortRequested()), matching the pattern the addon's other 
long-running threads (Library.run, the websocket client, the monitor listener) already use — so the thread exits promptly when Kodi begins shutting down.