### PR TITLE
Resume interrupted full sync automatically

### DIFF
--- a/jellyfin_kodi/full_sync.py
+++ b/jellyfin_kodi/full_sync.py
@@ -129,16 +129,7 @@ class FullSync(object):
         This allows us to restore a previous sync.
         """
         if self.sync["Libraries"]:
-
-            if not dialog("yesno", "{jellyfin}", translate(33102)):
-
-                if not dialog("yesno", "{jellyfin}", translate(33173)):
-                    dialog("ok", "{jellyfin}", translate(33122))
-
-                    raise LibraryException("ProgressStopped")
-                else:
-                    self.sync["Libraries"] = []
-                    self.sync["RestorePoint"] = {}
+            LOG.info("Resuming previous sync automatically.")
         else:
             LOG.info("generate full sync")
             libraries = []

--- a/tests/test_full_sync.py
+++ b/tests/test_full_sync.py
@@ -1,0 +1,25 @@
+from jellyfin_kodi import full_sync
+from jellyfin_kodi.full_sync import FullSync
+
+
+def test_mapping_resumes_pending_sync_without_dialog(monkeypatch):
+    restore_point = {"params": {"StartIndex": 100}}
+    sync_state = {
+        "Libraries": ["library-id"],
+        "RestorePoint": restore_point,
+    }
+    instance = FullSync.__new__(FullSync)
+    instance.sync = sync_state
+    saved = []
+
+    def unexpected_dialog(*args, **kwargs):
+        raise AssertionError("Interrupted sync recovery must not show a dialog")
+
+    monkeypatch.setattr(full_sync, "dialog", unexpected_dialog)
+    monkeypatch.setattr(full_sync, "save_sync", saved.append)
+
+    instance.mapping()
+
+    assert instance.sync["Libraries"] == ["library-id"]
+    assert instance.sync["RestorePoint"] == restore_point
+    assert saved == [sync_state]


### PR DESCRIPTION
## Changes

- automatically take the existing resume path when a full sync has pending libraries
- preserve the saved `Libraries` list and `RestorePoint`
- remove startup recovery dialogs that can block unattended or TV-based clients
- add a focused regression test proving no dialog is called and recovery state is unchanged

Fixes #1175.

Issue #1151 reported a separate sync hang and also observed unreliable restart recovery. This PR does not address the cause of a failed sync; it only makes recovery from already-persisted state deterministic and non-interactive.

## Validation

- `python -m pytest tests/test_full_sync.py -q` (`1 passed`)
- complete suite: `198 passed`
- fatal flake8 rules: `0` findings
- Black `26.1.0`: all 79 files compliant
- `git diff --check`
- behavior previously validated on Kodi 21.2 with Jellyfin for Kodi 2.1.0+py3