### PR TITLE
Fix segment skipper for multiple same type segments

### DIFF
--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -597,7 +597,7 @@ class Player(xbmc.Player):
                 continue
 
             start, end = bounds
-            
+
             LOG.debug(
                 "Skip check: IN WINDOW! segment_key=%s, already_prompted=%s",
                 segment_id,

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -597,16 +597,16 @@ class Player(xbmc.Player):
                 continue
 
             start, end = bounds
-            segment_key = segment_id
+            
             LOG.debug(
                 "Skip check: IN WINDOW! segment_key=%s, already_prompted=%s",
-                segment_key,
-                segment_key in self.skip_prompted,
+                segment_id,
+                segment_id in self.skip_prompted,
             )
-            if segment_key in self.skip_prompted:
+            if segment_id in self.skip_prompted:
                 continue
 
-            self.skip_prompted.add(segment_key)
+            self.skip_prompted.add(segment_id)
             LOG.debug(
                 "Skip check: Triggering _handle_skip_segment for %s", segment_type
             )

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -545,8 +545,9 @@ class Player(xbmc.Player):
         for item in response["Items"]:
             seg_type = type_map.get(item.get("Type"))
             if seg_type:
-                segments[seg_type] = {
+                segments[item.get("Id")] = {
                     "EpisodeId": item.get("ItemId"),
+                    "Type": seg_type,
                     "Start": item.get("StartTicks", 0) / 10000000.0,
                     "End": item.get("EndTicks", 0) / 10000000.0,
                 }
@@ -581,7 +582,10 @@ class Player(xbmc.Player):
         if not segments:
             return
 
-        for segment_type, segment in segments.items():
+        for segment_id, segment in segments.items():
+
+            segment_type = segment.get("Type")
+
             skip_mode = self._get_segment_skip_mode(segment_type)
             if skip_mode == 0:  # Off
                 continue
@@ -593,7 +597,7 @@ class Player(xbmc.Player):
                 continue
 
             start, end = bounds
-            segment_key = "%s:%s" % (item_id, segment_type)
+            segment_key = segment_id
             LOG.debug(
                 "Skip check: IN WINDOW! segment_key=%s, already_prompted=%s",
                 segment_key,

--- a/tests/test_media_segments.py
+++ b/tests/test_media_segments.py
@@ -1,21 +1,28 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, absolute_import, print_function, unicode_literals
 
+from jellyfin_kodi.player import Player
+
 import pytest
 
+@pytest.fixture
+def player():
+    return Player()
 
 class TestMediaSegmentsConversion:
 
-    def test_convert_media_segments_response(self):
+    def test_convert_media_segments_response(self, player):
         media_segments_response = {
             "Items": [
                 {
+                    "Id": "id-1",
                     "ItemId": "test-item-id",
                     "Type": "Intro",
                     "StartTicks": 425000000,
                     "EndTicks": 1220000000,
                 },
                 {
+                    "Id": "id-2",
                     "ItemId": "test-item-id",
                     "Type": "Outro",
                     "StartTicks": 24580000000,
@@ -24,38 +31,68 @@ class TestMediaSegmentsConversion:
             ]
         }
 
-        type_map = {
-            "Intro": "Introduction",
-            "Outro": "Credits",
-            "Recap": "Recap",
-            "Preview": "Preview",
-            "Commercial": "Commercial",
+        segments = player._convert_media_segments(media_segments_response)
+
+        assert "id-1" in segments
+        assert "id-2" in segments
+        assert segments["id-1"]["Start"] == pytest.approx(42.5)
+        assert segments["id-1"]["End"] == pytest.approx(122.0)
+        assert segments["id-2"]["Start"] == pytest.approx(2458.0)
+        assert segments["id-2"]["End"] == pytest.approx(2520.0)
+
+
+    def test_convert_media_segments_response_allows_multiple_of_same_type(self, player):
+        media_segments_response = {
+            "Items": [
+                {
+                    "Id": "id-1",
+                    "ItemId": "test-item-id",
+                    "Type": "Commercial",
+                    "StartTicks": 425000000,
+                    "EndTicks": 1220000000,
+                },
+                {
+                    "Id": "id-2",
+                    "ItemId": "test-item-id",
+                    "Type": "Commercial",
+                    "StartTicks": 1400000000,
+                    "EndTicks": 1500000000,
+                },
+                {
+                    "Id": "id-3",
+                    "ItemId": "test-item-id",
+                    "Type": "Outro",
+                    "StartTicks": 24580000000,
+                    "EndTicks": 25200000000,
+                },
+            ]
         }
 
-        segments = {}
-        for item in media_segments_response["Items"]:
-            seg_type = type_map.get(item.get("Type"))
-            if seg_type:
-                segments[seg_type] = {
-                    "EpisodeId": item.get("ItemId"),
-                    "Start": item.get("StartTicks", 0) / 10000000.0,
-                    "End": item.get("EndTicks", 0) / 10000000.0,
-                }
+        segments = player._convert_media_segments(media_segments_response)
 
-        assert "Introduction" in segments
-        assert "Credits" in segments
-        assert segments["Introduction"]["Start"] == pytest.approx(42.5)
-        assert segments["Introduction"]["End"] == pytest.approx(122.0)
-        assert segments["Credits"]["Start"] == pytest.approx(2458.0)
-        assert segments["Credits"]["End"] == pytest.approx(2520.0)
+        assert "id-1" in segments
+        assert "id-2" in segments
+        assert "id-3" in segments
+        assert segments["id-1"]["Start"] == pytest.approx(42.5)
+        assert segments["id-1"]["End"] == pytest.approx(122.0)
+        assert segments["id-2"]["Start"] == pytest.approx(140.0)
+        assert segments["id-2"]["End"] == pytest.approx(150.0)
+        assert segments["id-3"]["Start"] == pytest.approx(2458.0)
+        assert segments["id-3"]["End"] == pytest.approx(2520.0)
 
-    def test_convert_empty_media_segments(self):
+    def test_convert_empty_media_segments(self, player):
         response = {"Items": []}
-        assert len(response["Items"]) == 0
+        
+        segments = player._convert_media_segments(response)
 
-    def test_convert_media_segments_missing_items(self):
+        assert segments is None
+
+    def test_convert_media_segments_missing_items(self, player):
         response = {}
-        assert "Items" not in response
+        
+        segments = player._convert_media_segments(response)
+
+        assert segments is None
 
 
 class TestSegmentDetection:
@@ -77,15 +114,9 @@ class TestSegmentDetection:
         in_window = segment_start <= current_position <= segment_start + 5
         assert in_window == expected_in_window
 
-    def test_segment_key_generation(self):
-        item_id = "a1b2c3d4"
-        segment_type = "Introduction"
-        segment_key = "%s:%s" % (item_id, segment_type)
-        assert segment_key == "a1b2c3d4:Introduction"
-
     def test_skip_prompted_tracking(self):
         skip_prompted = set()
-        segment_key = "item123:Introduction"
+        segment_key = "id-1"
 
         assert segment_key not in skip_prompted
 

--- a/tests/test_media_segments.py
+++ b/tests/test_media_segments.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, absolute_import, print_function, unicode_literals
-from jellyfin_kodi.player import Player
 from unittest.mock import Mock
 
 import jellyfin_kodi.player as player_module
 import pytest
 
+
 @pytest.fixture
 def player():
-    return Player()
+    return player_module.Player()
+
 
 class TestMediaSegmentsConversion:
 
@@ -40,7 +41,6 @@ class TestMediaSegmentsConversion:
         assert segments["id-1"]["End"] == pytest.approx(122.0)
         assert segments["id-2"]["Start"] == pytest.approx(2458.0)
         assert segments["id-2"]["End"] == pytest.approx(2520.0)
-
 
     def test_convert_media_segments_response_allows_multiple_of_same_type(self, player):
         media_segments_response = {
@@ -83,14 +83,14 @@ class TestMediaSegmentsConversion:
 
     def test_convert_empty_media_segments(self, player):
         response = {"Items": []}
-        
+
         segments = player._convert_media_segments(response)
 
         assert segments is None
 
     def test_convert_media_segments_missing_items(self, player):
         response = {}
-        
+
         segments = player._convert_media_segments(response)
 
         assert segments is None
@@ -98,8 +98,10 @@ class TestMediaSegmentsConversion:
 
 class TestSegmentDetection:
 
-    def test_segment_skip_can_only_be_prompted_once_for_the_same_segment(self, monkeypatch, player):
-        
+    def test_segment_skip_can_only_be_prompted_once_for_the_same_segment(
+        self, monkeypatch, player
+    ):
+
         player.skip_prompted = set()
 
         skip_mode = 1
@@ -118,24 +120,33 @@ class TestSegmentDetection:
         }
 
         player.skip_segments["test-item-id"] = segments
-        
+
         player.check_skip_segments(item, 11)
         player.check_skip_segments(item, 12)
 
         assert "aa1" in player.skip_prompted
         assert len(player.skip_prompted) == 1
 
-    @pytest.mark.parametrize("current_position,segment_start,segment_end,should_skip",
+    @pytest.mark.parametrize(
+        "current_position,segment_start,segment_end,should_skip",
         [
             (42.5, 42.5, 122.0, True),
             (45.0, 42.5, 122.0, True),
             (122.0, 42.5, 122.0, True),
             (41.0, 42.5, 122.0, False),
-            (123.0, 42.5, 122.0, False)
+            (123.0, 42.5, 122.0, False),
         ],
     )
-    def test_segment_detection_window(self, monkeypatch, player, current_position, segment_start, segment_end, should_skip):
-        
+    def test_segment_detection_window(
+        self,
+        monkeypatch,
+        player,
+        current_position,
+        segment_start,
+        segment_end,
+        should_skip,
+    ):
+
         player.skip_prompted = set()
 
         skip_mode = 1
@@ -154,7 +165,7 @@ class TestSegmentDetection:
         }
 
         player.skip_segments["test-item-id"] = segments
-        
+
         player.check_skip_segments(item, current_position)
 
         if should_skip:
@@ -163,23 +174,27 @@ class TestSegmentDetection:
         else:
             assert len(player.skip_prompted) == 0
 
-
-    @pytest.mark.parametrize("segment_type,should_skip",
+    @pytest.mark.parametrize(
+        "segment_type,should_skip",
         [
             ("Introduction", True),
             ("Credits", True),
             ("Recap", True),
             ("Preview", True),
             ("Commercial", True),
-            ("Unknown", False)
+            ("Unknown", False),
         ],
     )
-    def test_only_mapped_segments_skipped(self, monkeypatch, player, segment_type, should_skip):
-        
+    def test_only_mapped_segments_skipped(
+        self, monkeypatch, player, segment_type, should_skip
+    ):
+
         player.skip_prompted = set()
 
-        player.played = {"":{"Type": "Episode"}} # "Credits" type falls into next_up() which requires this value to be set (and an empty string is the default stub filename)
-        
+        player.played = {
+            "": {"Type": "Episode"}
+        }  # "Credits" type falls into next_up() which requires this value to be set (and an empty string is the default stub filename)
+
         skip_mode = 1
         settings = Mock(return_value=skip_mode)
         monkeypatch.setattr(player_module, "settings", settings)
@@ -196,7 +211,7 @@ class TestSegmentDetection:
         }
 
         player.skip_segments["test-item-id"] = segments
-        
+
         player.check_skip_segments(item, 11)
 
         if should_skip:

--- a/tests/test_media_segments.py
+++ b/tests/test_media_segments.py
@@ -116,14 +116,14 @@ class TestSegmentDetection:
 
     def test_skip_prompted_tracking(self):
         skip_prompted = set()
-        segment_key = "id-1"
+        segment_id = "id-1"
 
-        assert segment_key not in skip_prompted
+        assert segment_id not in skip_prompted
 
-        skip_prompted.add(segment_key)
-        assert segment_key in skip_prompted
+        skip_prompted.add(segment_id)
+        assert segment_id in skip_prompted
 
-        skip_prompted.add(segment_key)
+        skip_prompted.add(segment_id)
         assert len(skip_prompted) == 1
 
 

--- a/tests/test_media_segments.py
+++ b/tests/test_media_segments.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, absolute_import, print_function, unicode_literals
-
 from jellyfin_kodi.player import Player
+from unittest.mock import Mock
 
+import jellyfin_kodi.player as player_module
 import pytest
 
 @pytest.fixture
@@ -97,82 +98,109 @@ class TestMediaSegmentsConversion:
 
 class TestSegmentDetection:
 
-    @pytest.mark.parametrize(
-        "current_position,segment_start,segment_end,expected_in_window",
+    def test_segment_skip_can_only_be_prompted_once_for_the_same_segment(self, monkeypatch, player):
+        
+        player.skip_prompted = set()
+
+        skip_mode = 1
+        settings = Mock(return_value=skip_mode)
+        monkeypatch.setattr(player_module, "settings", settings)
+
+        item = {"Id": "test-item-id"}
+
+        segments = {
+            "aa1": {
+                "EpisodeId": "test-item-id",
+                "Type": "Commercial",
+                "Start": 10,
+                "End": 20,
+            }
+        }
+
+        player.skip_segments["test-item-id"] = segments
+        
+        player.check_skip_segments(item, 11)
+        player.check_skip_segments(item, 12)
+
+        assert "aa1" in player.skip_prompted
+        assert len(player.skip_prompted) == 1
+
+    @pytest.mark.parametrize("current_position,segment_start,segment_end,should_skip",
         [
             (42.5, 42.5, 122.0, True),
             (45.0, 42.5, 122.0, True),
-            (47.5, 42.5, 122.0, True),
-            (48.0, 42.5, 122.0, False),
-            (40.0, 42.5, 122.0, False),
-            (100.0, 42.5, 122.0, False),
+            (122.0, 42.5, 122.0, True),
+            (41.0, 42.5, 122.0, False),
+            (123.0, 42.5, 122.0, False)
         ],
     )
-    def test_segment_detection_window(
-        self, current_position, segment_start, segment_end, expected_in_window
-    ):
-        in_window = segment_start <= current_position <= segment_start + 5
-        assert in_window == expected_in_window
+    def test_segment_detection_window(self, monkeypatch, player, current_position, segment_start, segment_end, should_skip):
+        
+        player.skip_prompted = set()
 
-    def test_skip_prompted_tracking(self):
-        skip_prompted = set()
-        segment_id = "id-1"
+        skip_mode = 1
+        settings = Mock(return_value=skip_mode)
+        monkeypatch.setattr(player_module, "settings", settings)
 
-        assert segment_id not in skip_prompted
+        item = {"Id": "test-item-id"}
 
-        skip_prompted.add(segment_id)
-        assert segment_id in skip_prompted
-
-        skip_prompted.add(segment_id)
-        assert len(skip_prompted) == 1
-
-
-class TestSkipModes:
-
-    def test_skip_mode_values(self):
-        AUTO_SKIP = 0
-        SHOW_BUTTON = 1
-        ASK_EVERY_TIME = 2
-
-        assert AUTO_SKIP == 0
-        assert SHOW_BUTTON == 1
-        assert ASK_EVERY_TIME == 2
-
-    def test_segment_type_settings_map(self):
-        setting_map = {
-            "Introduction": "skipIntroduction.bool",
-            "Credits": "skipCredits.bool",
-            "Recap": "skipRecap.bool",
-            "Preview": "skipPreview.bool",
-            "Commercial": "skipCommercial.bool",
+        segments = {
+            "aa1": {
+                "EpisodeId": "test-item-id",
+                "Type": "Commercial",
+                "Start": segment_start,
+                "End": segment_end,
+            }
         }
 
-        assert "Introduction" in setting_map
-        assert "Credits" in setting_map
-        assert "Recap" in setting_map
-        assert "Preview" in setting_map
-        assert "Commercial" in setting_map
-        assert setting_map["Introduction"] == "skipIntroduction.bool"
+        player.skip_segments["test-item-id"] = segments
+        
+        player.check_skip_segments(item, current_position)
+
+        if should_skip:
+            assert "aa1" in player.skip_prompted
+            assert len(player.skip_prompted) == 1
+        else:
+            assert len(player.skip_prompted) == 0
 
 
-class TestDurationFormatting:
-
-    @pytest.mark.parametrize(
-        "duration_seconds,expected_text",
+    @pytest.mark.parametrize("segment_type,should_skip",
         [
-            (30, "30s"),
-            (60, "1m 0s"),
-            (90, "1m 30s"),
-            (120, "2m 0s"),
-            (150, "2m 30s"),
-            (0, "0s"),
+            ("Introduction", True),
+            ("Credits", True),
+            ("Recap", True),
+            ("Preview", True),
+            ("Commercial", True),
+            ("Unknown", False)
         ],
     )
-    def test_duration_formatting(self, duration_seconds, expected_text):
-        minutes = int(duration_seconds // 60)
-        seconds = int(duration_seconds % 60)
-        if minutes > 0:
-            duration_text = "%dm %ds" % (minutes, seconds)
+    def test_only_mapped_segments_skipped(self, monkeypatch, player, segment_type, should_skip):
+        
+        player.skip_prompted = set()
+
+        player.played = {"":{"Type": "Episode"}} # "Credits" type falls into next_up() which requires this value to be set (and an empty string is the default stub filename)
+        
+        skip_mode = 1
+        settings = Mock(return_value=skip_mode)
+        monkeypatch.setattr(player_module, "settings", settings)
+
+        item = {"Id": "test-item-id"}
+
+        segments = {
+            "aa1": {
+                "EpisodeId": "test-item-id",
+                "Type": segment_type,
+                "Start": 10,
+                "End": 20,
+            }
+        }
+
+        player.skip_segments["test-item-id"] = segments
+        
+        player.check_skip_segments(item, 11)
+
+        if should_skip:
+            assert "aa1" in player.skip_prompted
+            assert len(player.skip_prompted) == 1
         else:
-            duration_text = "%ds" % seconds
-        assert duration_text == expected_text
+            assert len(player.skip_prompted) == 0


### PR DESCRIPTION
## Problem

I found that when media contains multiple segments of the same type (e.g. the media has multiple commercials), only the last one of that type is skipped.

This doesn't really affect most media (I assume most people are using Kodi and Jellyfin for TV shows that just have a single intro and outro)

My use case is my Jellyfin has videos from TubeArchivist (downloaded youtube videos), TubeArchivist has functionality to create segments in Jellyfin for commercials (corresponding to the commercials found by Sponsorblock). 

Youtube videos often have multiple commercial segments (e.g this video from Linus Tech Tips https://www.youtube.com/watch?v=J261Rg0LTDA) so I found that only the last one was being skipped by this plugin

The reason this is happening is that the code is storing the segments received from Jellyfin into a dictionary with the segment type being the key. This means that as new elements of the same segment type are added, the previous entry of that type is overwritten.

## Code change

My change instead uses the Id of the segment as the items key, this is returned by the call from Jellyfin and is unique per segment, so it seems sensible to use as the key.

I also tweaked the already prompted check in check_skip_segments to ensure that this also takes into account the segment id.

## Testing

I temporarily added a log to capture the state of the segments before and after addition to the dictionary
<img width="551" height="524" alt="logs" src="https://github.com/user-attachments/assets/42deff61-3c8f-4cbb-8c86-f43edab7b251" />

The value of the response variable is

<img width="757" height="853" alt="after-segments-before" src="https://github.com/user-attachments/assets/8bcae469-6c5e-49cd-9846-7eb9bd9bb9d5" />

Before my code change the value of the segments variable is

<img width="997" height="517" alt="before-segments" src="https://github.com/user-attachments/assets/9cc7d86c-4249-4610-947e-5ee9c2b8079d" />

After my code change the value of the segments variable is

<img width="763" height="714" alt="after-segments-after" src="https://github.com/user-attachments/assets/d6c1917a-4d2b-4741-8550-f83046e25628" />


Notice that the first commercial is now present


Before my code change, this results in the first commercial not skipping

<img width="1920" height="1080" alt="before-firstseg-fail" src="https://github.com/user-attachments/assets/5b4af37f-9421-47e1-a293-08a936722efb" />



After my code change the skip dialog (or whatever you have it configured to) now works on the first commercial

<img width="1920" height="1080" alt="after-firstseg-success" src="https://github.com/user-attachments/assets/ebfdade2-64fe-49c5-87bb-80e89b3b4d50" />
 

 Still works on the last one
 
<img width="1920" height="1080" alt="after-lastseg-success" src="https://github.com/user-attachments/assets/2f363118-2c15-4618-955b-6f1a59c369de" />


The already prompted check also still works (temp bumped it to info so I didn't have to change the log level)

<img width="1478" height="223" alt="after-already-prompted-still-working" src="https://github.com/user-attachments/assets/ce505b2d-256b-4687-bde4-b5665708515f" />


AI was **not** used to produce this pull request