### PR TITLE
feat(playutils): include descriptive title in subtitle filenames

### DIFF
--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -4,6 +4,7 @@ from __future__ import division, absolute_import, print_function, unicode_litera
 #################################################################################################
 
 import os
+import re
 from uuid import uuid4
 
 import requests
@@ -555,8 +556,13 @@ class PlayUtils(object):
                 LOG.info("[ subtitles/%s ] %s", index, url)
 
                 if "Language" in stream:
-                    filename = "%s.%s.%s" % (
-                        source["Id"],
+                    title = re.sub(r"[^A-Za-z0-9]+", "", stream.get("Title") or "")
+                    display_title = re.sub(
+                        r"[^A-Za-z0-9]+", "", stream.get("DisplayTitle") or ""
+                    )
+                    filename = "%s.%s.%s.%s" % (
+                        title or display_title or "sub",
+                        f'{source["Id"]}-{index}',
                         stream["Language"],
                         stream["Codec"],
                     )


### PR DESCRIPTION
Subtitle stream filenames now include a sanitized version of the stream's title or display title, along with the stream index, in addition to the existing source ID, language, and codec. This makes it easier to distinguish between multiple subtitle tracks with the same language when selecting subtitles in the player.