### PR TITLE
fix(tvshows): skip episodes whose library is not whitelisted

### DIFF
--- a/jellyfin_kodi/objects/tvshows.py
+++ b/jellyfin_kodi/objects/tvshows.py
@@ -401,7 +401,9 @@ class TVShows(KodiDb):
         obj["Audio"] = API.audio_streams(obj["Audio"] or [])
         obj["Streams"] = API.media_streams(obj["Video"], obj["Audio"], obj["Subtitles"])
 
-        self.get_episode_path_filename(obj)
+        if not self.get_episode_path_filename(obj):
+            # This item doesn't belong to a whitelisted library
+            return
 
         if obj["Premiere"]:
             obj["Premiere"] = Local(obj["Premiere"]).split(".")[0].replace("T", " ")
@@ -518,7 +520,10 @@ class TVShows(KodiDb):
         )
 
     def get_episode_path_filename(self, obj):
-        """Get the path and build it into protocol://path"""
+        """Get the path and build it into protocol://path
+
+        Returns False when the item belongs to no whitelisted library.
+        """
         if "\\" in obj["Path"]:
             obj["Filename"] = obj["Path"].rsplit("\\", 1)[1]
         else:
@@ -548,6 +553,10 @@ class TVShows(KodiDb):
         else:
             # We need LibraryId
             library = self.library or find_library(self.server, obj)
+            if not library:
+                # This item doesn't belong to a whitelisted library
+                return False
+
             obj["LibraryId"] = library["Id"]
             obj["Path"] = "plugin://plugin.video.jellyfin/%s/%s/" % (
                 obj["LibraryId"],
@@ -561,6 +570,8 @@ class TVShows(KodiDb):
             }
             obj["Filename"] = "%s?%s" % (obj["Path"], urlencode(params))
             obj["FullFilePath"] = obj["Filename"]
+
+        return True
 
     def get_show_id(self, obj):
         obj["ShowId"] = self.jellyfin_db.get_item_by_id(

--- a/tests/test_tvshows_episode_path.py
+++ b/tests/test_tvshows_episode_path.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+from __future__ import division, absolute_import, print_function, unicode_literals
+
+import pytest
+
+from jellyfin_kodi.objects import tvshows
+from jellyfin_kodi.objects.tvshows import TVShows
+
+LIBRARY_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+SERIES_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+EPISODE_ITEM_ID = "cccccccccccccccccccccccccccccccc"
+
+
+class FakeTVShows(object):
+    """Stand-in for TVShows; get_episode_path_filename only reads these attributes."""
+
+    def __init__(self, direct_path=False, library=None):
+        self.direct_path = direct_path
+        self.library = library
+        self.server = object()
+
+
+def episode_obj():
+    return {
+        "Path": "/media/tvshows/Some Show (2024)/Some Show S01E01.mkv",
+        "Id": EPISODE_ITEM_ID,
+        "SeriesId": SERIES_ID,
+        "EpisodeId": 42,
+    }
+
+
+def call(fake, obj):
+    return TVShows.get_episode_path_filename(fake, obj)
+
+
+def test_skips_item_outside_whitelisted_library(monkeypatch):
+    """find_library returns {} for items outside the whitelist; skip instead of raising."""
+    monkeypatch.setattr(tvshows, "find_library", lambda server, obj: {})
+    obj = episode_obj()
+
+    assert call(FakeTVShows(), obj) is False
+    assert "LibraryId" not in obj
+
+
+def test_builds_plugin_path_for_whitelisted_library(monkeypatch):
+    monkeypatch.setattr(
+        tvshows, "find_library", lambda server, obj: {"Id": LIBRARY_ID, "Name": "TV"}
+    )
+    obj = episode_obj()
+
+    assert call(FakeTVShows(), obj) is True
+    assert obj["LibraryId"] == LIBRARY_ID
+    assert obj["Path"] == "plugin://plugin.video.jellyfin/%s/%s/" % (
+        LIBRARY_ID,
+        SERIES_ID,
+    )
+    assert obj["Filename"].startswith(obj["Path"] + "?")
+    assert "id=%s" % EPISODE_ITEM_ID in obj["Filename"]
+    assert obj["FullFilePath"] == obj["Filename"]
+
+
+def test_known_library_skips_the_lookup(monkeypatch):
+    """During a full library sync self.library is set and find_library is never called."""
+
+    def boom(server, obj):
+        raise AssertionError("find_library must not be called when self.library is set")
+
+    monkeypatch.setattr(tvshows, "find_library", boom)
+    obj = episode_obj()
+
+    assert call(FakeTVShows(library={"Id": LIBRARY_ID}), obj) is True
+    assert obj["LibraryId"] == LIBRARY_ID
+
+
+@pytest.mark.parametrize(
+    "path", ["/media/tv/Show/Show S01E01.mkv", "C:\\tv\\Show\\Show S01E01.mkv"]
+)
+def test_direct_path_mode_is_unaffected(monkeypatch, path):
+    monkeypatch.setattr(tvshows, "validate", lambda p: True)
+    monkeypatch.setattr(tvshows, "validate_dvd_dir", lambda p: False)
+    monkeypatch.setattr(tvshows, "validate_bluray_dir", lambda p: False)
+
+    def boom(server, obj):
+        raise AssertionError("find_library must not be called in direct path mode")
+
+    monkeypatch.setattr(tvshows, "find_library", boom)
+    obj = episode_obj()
+    obj["Path"] = path
+
+    assert call(FakeTVShows(direct_path=True), obj) is True
+    assert obj["Filename"] == "Show S01E01.mkv"
+    assert obj["FullFilePath"] == obj["Path"] + obj["Filename"]


### PR DESCRIPTION
### Problem

`get_episode_path_filename()` calls `find_library()` without checking the result.
`find_library()` returns an empty dict when an item belongs to no whitelisted library
(`helper/utils.py:560-571`), so the next line raises instead of skipping the item:

```python
library = self.library or find_library(self.server, obj)
obj["LibraryId"] = library["Id"]      # KeyError: 'Id'
```

```
File "jellyfin_kodi/objects/tvshows.py", line 404, in episode
    self.get_episode_path_filename(obj)
File "jellyfin_kodi/objects/tvshows.py", line 551, in get_episode_path_filename
    obj["LibraryId"] = library["Id"]
KeyError: 'Id'
```

Seven of the eight `find_library()` call sites already guard against the empty result with
`if not library: return`. This is the only one that does not.

The two guards inside `episode()` (lines 87 and 369) do not cover this path: they sit in the
`except TypeError` branch and therefore only run for items the add-on database does not know
yet. An update for an **already known** item takes the `else` branch, reaches line 404 and
raises in 551.

### How it shows up

On a live install, one library was dropped from the whitelist while its items stayed in the
Kodi database. Every incoming update for those items then produced a traceback instead of
being skipped: **278 tracebacks in two minutes**, one per item.

Skipping is the correct behaviour here, the item genuinely belongs to no whitelisted library.
Raising is not.

### Fix

`get_episode_path_filename()` returns `False` when the library is missing, and `episode()`
skips the item, matching the existing `get_show_id()` pattern a few lines below.

### Tests

Five new unit tests in `tests/test_tvshows_episode_path.py`, all red before the change (the
first one with the exact `KeyError: 'Id'` above). Suite goes from 197 to 202 passing.
`flake8 --select=E9,F63,F7,F82` and `black --check` are clean, mypy is unchanged at its
existing baseline.

### Verified against a real install

Same add-on, same data, whitelist entry removed and `LastIncrementalSync` rewound so the same
change set is processed twice:

| build | items skipped | `KeyError: 'Id'` |
|---|---|---|
| unpatched | 554 | **554** |
| patched | 278 | **0** |

The two absolute counts are not comparable, the runs covered different numbers of change
blocks. What is comparable is the ratio: one traceback per skipped item before, none after.
Confirmed on the same item id present in both runs. Library counts were unchanged afterwards.