### PR TITLE
Avoid errors at upgrade/uninstall

### DIFF
--- a/jellyfin_kodi/entrypoint/service.py
+++ b/jellyfin_kodi/entrypoint/service.py
@@ -74,7 +74,7 @@ class Service(xbmc.Monitor):
         if self.settings["enable_context_transcode"]:
             window("jellyfin_context_transcode.bool", True)
 
-        LOG.info("--->>>[ %s ]", client.get_addon_name())
+        LOG.info("--->>>[ JELLYFIN ]")
         LOG.info("Version: %s", client.get_version())
         LOG.info("KODI Version: %s", xbmc.getInfoLabel("System.BuildVersion"))
         LOG.info("Platform: %s", settings("platformDetected"))
@@ -532,4 +532,4 @@ class Service(xbmc.Monitor):
 
             self.monitor.listener.stop()
 
-        LOG.info("---<<<[ %s ]", client.get_addon_name())
+        LOG.info("---<<<[ JELLYFIN ]")

--- a/jellyfin_kodi/helper/loghandler.py
+++ b/jellyfin_kodi/helper/loghandler.py
@@ -82,8 +82,11 @@ class LogHandler(logging.StreamHandler):
         }
         try:
             log_level = int(settings("logLevel"))
-        except ValueError:
-            log_level = 2  # If getting settings fail, we probably want debug logging.
+        except (ValueError, RuntimeError):
+            # If getting settings fail, we probably want debug logging.
+            # ValueError happens if the result is not a number
+            # RuntimeError happens if the addon is being re-installed
+            log_level = 2
 
         return log_level >= levels[level]
 


### PR DESCRIPTION
When Kodi is tearing down the add-on, `xbmcaddon.Addon` is not available. Relying on it without wrapping it in a `RuntimeError` reports an exception in the logs and causes a notification to appear with the complaint. Wrap only some instances of it very narrowly to avoid such issues. Note that this prevents RuntimeError traces from this add-on in the logs, as well as the notifications; however, it does not prevent Kodi's own logs of the format `EXCEPTION: Unknown addon id`.

Based on #1163
Fixes #324 

Example logs, with this patch added, when re-installing the add-on over itself
```
2026-09-02 14:54:57.266 T:3560587   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.266 T:3560587    info <general>: JELLYFIN.jellyfin_kodi.monitor -> INFO::jellyfin_kodi/monitor.py:387 ---<[ listener ]
2026-09-02 14:54:57.266 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.266 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.entrypoint.service -> INFO::jellyfin_kodi/entrypoint/service.py:506 ---<[ EXITING ]
2026-09-02 14:54:57.266 T:3560607   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.266 T:3560607    info <general>: JELLYFIN.jellyfin_kodi.library -> INFO::jellyfin_kodi/library.py:111 ---<[ library ]
2026-09-02 14:54:57.266 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.266 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.helper.utils -> DEBUG::jellyfin_kodi/helper/utils.py:54 --[ window clear: jellyfin_state ]
2026-09-02 14:54:57.266 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.266 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.helper.utils -> DEBUG::jellyfin_kodi/helper/utils.py:54 --[ window clear: jellyfin_serverStatus ]
2026-09-02 14:54:57.266 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.267 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.helper.utils -> DEBUG::jellyfin_kodi/helper/utils.py:54 --[ window clear: jellyfin_currUser ]
2026-09-02 14:54:57.267 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.267 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.helper.utils -> DEBUG::jellyfin_kodi/helper/utils.py:54 --[ window clear: jellyfin_play ]
2026-09-02 14:54:57.267 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.267 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.helper.utils -> DEBUG::jellyfin_kodi/helper/utils.py:54 --[ window clear: jellyfin_online ]
2026-09-02 14:54:57.267 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.267 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.helper.utils -> DEBUG::jellyfin_kodi/helper/utils.py:54 --[ window clear: jellyfin.connected ]
2026-09-02 14:54:57.267 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.267 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.helper.utils -> DEBUG::jellyfin_kodi/helper/utils.py:54 --[ window clear: jellyfin_startup ]
2026-09-02 14:54:57.267 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.267 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.helper.utils -> DEBUG::jellyfin_kodi/helper/utils.py:54 --[ window clear: jellyfin.external ]
2026-09-02 14:54:57.267 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.267 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.helper.utils -> DEBUG::jellyfin_kodi/helper/utils.py:54 --[ window clear: jellyfin.external_check ]
2026-09-02 14:54:57.267 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.267 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.helper.utils -> DEBUG::jellyfin_kodi/helper/utils.py:54 --[ window clear: jellyfin_deviceId ]
2026-09-02 14:54:57.267 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.267 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.helper.utils -> DEBUG::jellyfin_kodi/helper/utils.py:54 --[ window clear: jellyfin_db_check ]
2026-09-02 14:54:57.267 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.267 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.helper.utils -> DEBUG::jellyfin_kodi/helper/utils.py:54 --[ window clear: jellyfin_pathverified ]
2026-09-02 14:54:57.267 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.267 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.helper.utils -> DEBUG::jellyfin_kodi/helper/utils.py:54 --[ window clear: jellyfin_sync ]
2026-09-02 14:54:57.267 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.268 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.jellyfin.http -> INFO::jellyfin_kodi/jellyfin/http.py:51 --<[ session/139922826535616 ]
2026-09-02 14:54:57.268 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.268 T:3560586    info <general>: JELLYFIN -> INFO::jellyfin_kodi/jellyfin/__init__.py:75 ---[ STOPPED ALL JELLYFINCLIENTS ]---
2026-09-02 14:54:57.268 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.268 T:3560586    info <general>: JELLYFIN.jellyfin_kodi.entrypoint.service -> INFO::jellyfin_kodi/entrypoint/service.py:536 ---<<<[ JELLYFIN ]
2026-09-02 14:54:57.268 T:3560586   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.268 T:3560586    info <general>: JELLYFIN.__main__ -> ERROR::service.py:43 ExitService
                                                   Traceback (most recent call last):
                                                     File "service.py", line 41, in run
                                                       service.service()
                                                       ~~~~~~~~~~~~~~~^^
                                                     File "jellyfin_kodi/entrypoint/service.py", line 149, in service
                                                       raise Exception("ExitService")
                                                   Exception: ExitService

2026-09-02 14:54:57.268 T:3560529   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:54:57.268 T:3560529    info <general>: JELLYFIN.__main__ -> INFO::service.py:80 --<[ service ]
2026-09-02 14:54:58.547 T:3560541 warning <general>: void ADDON::CAddonMgr::FindAddons(ADDON::AddonInfoMap&, const std::string&) const: Addon 'game.controller.snes' already present with higher version 1.0.49 at '/usr/share/kodi/addons/game.controller.snes/' - other version 1.0.43 at '/home/user/.kodi/addons/game.controller.snes/' will be ignored
2026-09-02 14:54:58.547 T:3560541 warning <general>: void ADDON::CAddonMgr::FindAddons(ADDON::AddonInfoMap&, const std::string&) const: Addon 'metadata.common.fanart.tv' already present with higher version 3.6.5 at '/usr/share/kodi/addons/metadata.common.fanart.tv/' - other version 3.6.4 at '/home/user/.kodi/addons/metadata.common.fanart.tv/' will be ignored
2026-09-02 14:54:58.550 T:3560541    info <general>: Addon Manager: Found addon: 'plugin.video.jellyfin v2.1.0+py3'
2026-09-02 14:54:58.679 T:3560893    info <general>: JELLYFIN.__main__ -> INFO::service.py:57 -->[ service ]
2026-09-02 14:54:58.679 T:3560893    info <general>: JELLYFIN.__main__ -> INFO::service.py:58 Delay startup by 0 seconds.
2026-09-02 14:54:58.694 T:3560898    info <general>: JELLYFIN.jellyfin_kodi.entrypoint.service -> INFO::jellyfin_kodi/entrypoint/service.py:78 --->>>[ JELLYFIN ]
```

Logs without this patch at commit 6fe19b604453fb35d47a340225145592b268fea8
```
2026-09-02 14:57:59.457 T:3563582   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:57:59.457 T:3563582   error <general>: Exception in thread
2026-09-02 14:57:59.457 T:3563582   error <general>: Thread-3
2026-09-02 14:57:59.457 T:3563582   error <general>: :

2026-09-02 14:57:59.457 T:3563581   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:57:59.457 T:3563581   error <general>: Skipped 1 duplicate messages..
2026-09-02 14:57:59.457 T:3563581   error <general>: Exception in thread
2026-09-02 14:57:59.457 T:3563581   error <general>: Thread-2
2026-09-02 14:57:59.457 T:3563581   error <general>: :

2026-09-02 14:57:59.457 T:3563608   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:57:59.457 T:3563608   error <general>: Exception in thread
2026-09-02 14:57:59.457 T:3563608   error <general>: Thread-6
2026-09-02 14:57:59.457 T:3563608   error <general>: :

2026-09-02 14:57:59.459 T:3563582   error <general>: Traceback (most recent call last):

2026-09-02 14:57:59.459 T:3563582   error <general>:
2026-09-02 14:57:59.459 T:3563582   error <general>:   File "/usr/lib/python3.14/threading.py", line 1082, in _bootstrap_inner
                                                       self._context.run(self.run)
                                                       ~~~~~~~~~~~~~~~~~^^^^^^^^^^

2026-09-02 14:57:59.459 T:3563582   error <general>:
2026-09-02 14:57:59.459 T:3563582   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/monitor.py", line 387, in run
                                                       LOG.info("---<[ listener ]")
                                                       ~~~~~~~~^^^^^^^^^^^^^^^^^^^^

2026-09-02 14:57:59.459 T:3563582   error <general>:
2026-09-02 14:57:59.459 T:3563582   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1520, in info
                                                       self._log(INFO, msg, args, **kwargs)
                                                       ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^

2026-09-02 14:57:59.459 T:3563582   error <general>:
2026-09-02 14:57:59.459 T:3563582   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1665, in _log
                                                       self.handle(record)
                                                       ~~~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.459 T:3563582   error <general>:
2026-09-02 14:57:59.459 T:3563582   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1681, in handle
                                                       self.callHandlers(record)
                                                       ~~~~~~~~~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.459 T:3563582   error <general>:
2026-09-02 14:57:59.459 T:3563582   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1741, in callHandlers
                                                       hdlr.handle(record)
                                                       ~~~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.459 T:3563582   error <general>:
2026-09-02 14:57:59.459 T:3563582   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1027, in handle
                                                       self.emit(record)
                                                       ~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.459 T:3563582   error <general>:
2026-09-02 14:57:59.459 T:3563582   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/helper/loghandler.py", line 58, in emit
                                                       if self._get_log_level(record.levelno):
                                                          ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^

2026-09-02 14:57:59.459 T:3563582   error <general>:
2026-09-02 14:57:59.459 T:3563582   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/helper/loghandler.py", line 84, in _get_log_level
                                                       log_level = int(settings("logLevel"))
                                                                       ~~~~~~~~^^^^^^^^^^^^

2026-09-02 14:57:59.459 T:3563582   error <general>:
2026-09-02 14:57:59.459 T:3563582   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/helper/utils.py", line 84, in settings
                                                       addon = xbmcaddon.Addon(addon_id())

2026-09-02 14:57:59.459 T:3563582   error <general>:
2026-09-02 14:57:59.459 T:3563582   error <general>: RuntimeError: Unknown addon id 'plugin.video.jellyfin'.

2026-09-02 14:57:59.459 T:3563582   error <general>:
2026-09-02 14:57:59.460 T:3563608   error <general>: Traceback (most recent call last):

2026-09-02 14:57:59.460 T:3563608   error <general>:
2026-09-02 14:57:59.460 T:3563608   error <general>:   File "/usr/lib/python3.14/threading.py", line 1082, in _bootstrap_inner
                                                       self._context.run(self.run)
                                                       ~~~~~~~~~~~~~~~~~^^^^^^^^^^

2026-09-02 14:57:59.460 T:3563608   error <general>:
2026-09-02 14:57:59.460 T:3563608   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/library.py", line 111, in run
                                                       LOG.info("---<[ library ]")
                                                       ~~~~~~~~^^^^^^^^^^^^^^^^^^^

2026-09-02 14:57:59.460 T:3563608   error <general>:
2026-09-02 14:57:59.460 T:3563608   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1520, in info
                                                       self._log(INFO, msg, args, **kwargs)
                                                       ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^

2026-09-02 14:57:59.460 T:3563608   error <general>:
2026-09-02 14:57:59.460 T:3563608   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1665, in _log
                                                       self.handle(record)
                                                       ~~~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.460 T:3563608   error <general>:
2026-09-02 14:57:59.460 T:3563608   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1681, in handle
                                                       self.callHandlers(record)
                                                       ~~~~~~~~~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.460 T:3563608   error <general>:
2026-09-02 14:57:59.460 T:3563608   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1741, in callHandlers
                                                       hdlr.handle(record)
                                                       ~~~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.460 T:3563608   error <general>:
2026-09-02 14:57:59.460 T:3563608   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1027, in handle
                                                       self.emit(record)
                                                       ~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.460 T:3563608   error <general>:
2026-09-02 14:57:59.460 T:3563608   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/helper/loghandler.py", line 58, in emit
                                                       if self._get_log_level(record.levelno):
                                                          ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^

2026-09-02 14:57:59.460 T:3563608   error <general>:
2026-09-02 14:57:59.460 T:3563608   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/helper/loghandler.py", line 84, in _get_log_level
                                                       log_level = int(settings("logLevel"))
                                                                       ~~~~~~~~^^^^^^^^^^^^

2026-09-02 14:57:59.460 T:3563608   error <general>:
2026-09-02 14:57:59.460 T:3563608   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/helper/utils.py", line 84, in settings
                                                       addon = xbmcaddon.Addon(addon_id())

2026-09-02 14:57:59.460 T:3563608   error <general>:
2026-09-02 14:57:59.460 T:3563608   error <general>: RuntimeError: Unknown addon id 'plugin.video.jellyfin'.

2026-09-02 14:57:59.460 T:3563608   error <general>:
2026-09-02 14:57:59.460 T:3563581   error <general>: Traceback (most recent call last):

2026-09-02 14:57:59.460 T:3563581   error <general>:
2026-09-02 14:57:59.460 T:3563581   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/service.py", line 41, in run
                                                       service.service()
                                                       ~~~~~~~~~~~~~~~^^

2026-09-02 14:57:59.460 T:3563581   error <general>:
2026-09-02 14:57:59.460 T:3563581   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/entrypoint/service.py", line 146, in service
                                                       self.shutdown()
                                                       ~~~~~~~~~~~~~^^

2026-09-02 14:57:59.460 T:3563581   error <general>:
2026-09-02 14:57:59.460 T:3563581   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/entrypoint/service.py", line 505, in shutdown
                                                       LOG.info("---<[ EXITING ]")
                                                       ~~~~~~~~^^^^^^^^^^^^^^^^^^^

2026-09-02 14:57:59.460 T:3563581   error <general>:
2026-09-02 14:57:59.460 T:3563581   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1520, in info
                                                       self._log(INFO, msg, args, **kwargs)
                                                       ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^

2026-09-02 14:57:59.460 T:3563581   error <general>:
2026-09-02 14:57:59.460 T:3563581   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1665, in _log
                                                       self.handle(record)
                                                       ~~~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.460 T:3563581   error <general>:
2026-09-02 14:57:59.460 T:3563581   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1681, in handle
                                                       self.callHandlers(record)
                                                       ~~~~~~~~~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.460 T:3563581   error <general>:
2026-09-02 14:57:59.460 T:3563581   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1741, in callHandlers
                                                       hdlr.handle(record)
                                                       ~~~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.460 T:3563581   error <general>:
2026-09-02 14:57:59.460 T:3563581   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1027, in handle
                                                       self.emit(record)
                                                       ~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.460 T:3563581   error <general>:
2026-09-02 14:57:59.460 T:3563581   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/helper/loghandler.py", line 58, in emit
                                                       if self._get_log_level(record.levelno):
                                                          ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^

2026-09-02 14:57:59.460 T:3563581   error <general>:
2026-09-02 14:57:59.460 T:3563581   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/helper/loghandler.py", line 84, in _get_log_level
                                                       log_level = int(settings("logLevel"))
                                                                       ~~~~~~~~^^^^^^^^^^^^

2026-09-02 14:57:59.460 T:3563581   error <general>:
2026-09-02 14:57:59.460 T:3563581   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/helper/utils.py", line 84, in settings
                                                       addon = xbmcaddon.Addon(addon_id())

2026-09-02 14:57:59.460 T:3563581   error <general>:
2026-09-02 14:57:59.460 T:3563581   error <general>: RuntimeError: Unknown addon id 'plugin.video.jellyfin'.

2026-09-02 14:57:59.460 T:3563581   error <general>:
2026-09-02 14:57:59.460 T:3563581   error <general>:
                                                   During handling of the above exception, another exception occurred:


2026-09-02 14:57:59.460 T:3563581   error <general>:
2026-09-02 14:57:59.460 T:3563581   error <general>: Traceback (most recent call last):

2026-09-02 14:57:59.460 T:3563581   error <general>:
2026-09-02 14:57:59.461 T:3563581   error <general>:   File "/usr/lib/python3.14/threading.py", line 1082, in _bootstrap_inner
                                                       self._context.run(self.run)
                                                       ~~~~~~~~~~~~~~~~~^^^^^^^^^^

2026-09-02 14:57:59.461 T:3563581   error <general>:
2026-09-02 14:57:59.461 T:3563581   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/service.py", line 43, in run
                                                       LOG.exception(error)
                                                       ~~~~~~~~~~~~~^^^^^^^

2026-09-02 14:57:59.461 T:3563581   error <general>:
2026-09-02 14:57:59.461 T:3563581   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1555, in exception
                                                       self.error(msg, *args, exc_info=exc_info, **kwargs)
                                                       ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

2026-09-02 14:57:59.461 T:3563581   error <general>:
2026-09-02 14:57:59.461 T:3563581   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1549, in error
                                                       self._log(ERROR, msg, args, **kwargs)
                                                       ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^

2026-09-02 14:57:59.461 T:3563581   error <general>:
2026-09-02 14:57:59.461 T:3563581   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1665, in _log
                                                       self.handle(record)
                                                       ~~~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.461 T:3563581   error <general>:
2026-09-02 14:57:59.461 T:3563581   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1681, in handle
                                                       self.callHandlers(record)
                                                       ~~~~~~~~~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.461 T:3563581   error <general>:
2026-09-02 14:57:59.461 T:3563581   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1741, in callHandlers
                                                       hdlr.handle(record)
                                                       ~~~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.461 T:3563581   error <general>:
2026-09-02 14:57:59.461 T:3563581   error <general>:   File "/usr/lib/python3.14/logging/__init__.py", line 1027, in handle
                                                       self.emit(record)
                                                       ~~~~~~~~~^^^^^^^^

2026-09-02 14:57:59.461 T:3563581   error <general>:
2026-09-02 14:57:59.461 T:3563581   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/helper/loghandler.py", line 58, in emit
                                                       if self._get_log_level(record.levelno):
                                                          ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^

2026-09-02 14:57:59.461 T:3563581   error <general>:
2026-09-02 14:57:59.461 T:3563581   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/helper/loghandler.py", line 84, in _get_log_level
                                                       log_level = int(settings("logLevel"))
                                                                       ~~~~~~~~^^^^^^^^^^^^

2026-09-02 14:57:59.461 T:3563581   error <general>:
2026-09-02 14:57:59.461 T:3563581   error <general>:   File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/helper/utils.py", line 84, in settings
                                                       addon = xbmcaddon.Addon(addon_id())

2026-09-02 14:57:59.461 T:3563581   error <general>:
2026-09-02 14:57:59.461 T:3563581   error <general>: RuntimeError: Unknown addon id 'plugin.video.jellyfin'.

2026-09-02 14:57:59.461 T:3563581   error <general>:
2026-09-02 14:57:59.461 T:3563506   error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.
2026-09-02 14:57:59.461 T:3563506   error <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'RuntimeError'>
                                                   Error Contents: Unknown addon id 'plugin.video.jellyfin'.
                                                   Traceback (most recent call last):
                                                     File "/home/user/.kodi/addons/plugin.video.jellyfin/service.py", line 80, in <module>
                                                       LOG.info("--<[ service ]")
                                                       ~~~~~~~~^^^^^^^^^^^^^^^^^^
                                                     File "/usr/lib/python3.14/logging/__init__.py", line 1520, in info
                                                       self._log(INFO, msg, args, **kwargs)
                                                       ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                     File "/usr/lib/python3.14/logging/__init__.py", line 1665, in _log
                                                       self.handle(record)
                                                       ~~~~~~~~~~~^^^^^^^^
                                                     File "/usr/lib/python3.14/logging/__init__.py", line 1681, in handle
                                                       self.callHandlers(record)
                                                       ~~~~~~~~~~~~~~~~~^^^^^^^^
                                                     File "/usr/lib/python3.14/logging/__init__.py", line 1741, in callHandlers
                                                       hdlr.handle(record)
                                                       ~~~~~~~~~~~^^^^^^^^
                                                     File "/usr/lib/python3.14/logging/__init__.py", line 1027, in handle
                                                       self.emit(record)
                                                       ~~~~~~~~~^^^^^^^^
                                                     File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/helper/loghandler.py", line 58, in emit
                                                       if self._get_log_level(record.levelno):
                                                          ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
                                                     File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/helper/loghandler.py", line 84, in _get_log_level
                                                       log_level = int(settings("logLevel"))
                                                                       ~~~~~~~~^^^^^^^^^^^^
                                                     File "/home/user/.kodi/addons/plugin.video.jellyfin/jellyfin_kodi/helper/utils.py", line 84, in settings
                                                       addon = xbmcaddon.Addon(addon_id())
                                                   RuntimeError: Unknown addon id 'plugin.video.jellyfin'.
                                                   -->End of Python script error report<--

2026-09-02 14:57:59.461 T:3563506    info <general>: CPythonInvoker(1, /home/user/.kodi/addons/plugin.video.jellyfin/service.py): waiting on thread 140129428256448
2026-09-02 14:58:04.470 T:3563493   error <general>: CPythonInvoker(1, /home/user/.kodi/addons/plugin.video.jellyfin/service.py): script didn't stop in 5 seconds - let's kill it
2026-09-02 14:58:05.733 T:3563493 warning <general>: void ADDON::CAddonMgr::FindAddons(ADDON::AddonInfoMap&, const std::string&) const: Addon 'game.controller.snes' already present with higher version 1.0.49 at '/usr/share/kodi/addons/game.controller.snes/' - other version 1.0.43 at '/home/user/.kodi/addons/game.controller.snes/' will be ignored
2026-09-02 14:58:05.733 T:3563493 warning <general>: void ADDON::CAddonMgr::FindAddons(ADDON::AddonInfoMap&, const std::string&) const: Addon 'metadata.common.fanart.tv' already present with higher version 3.6.5 at '/usr/share/kodi/addons/metadata.common.fanart.tv/' - other version 3.6.4 at '/home/user/.kodi/addons/metadata.common.fanart.tv/' will be ignored
2026-09-02 14:58:05.735 T:3563493    info <general>: Addon Manager: Found addon: 'plugin.video.jellyfin v2.1.0+py3'
2026-09-02 14:58:05.863 T:3564159    info <general>: JELLYFIN.__main__ -> INFO::service.py:57 -->[ service ]
2026-09-02 14:58:05.863 T:3564159    info <general>: JELLYFIN.__main__ -> INFO::service.py:58 Delay startup by 0 seconds.
2026-09-02 14:58:05.895 T:3564165    info <general>: JELLYFIN.jellyfin_kodi.entrypoint.service -> INFO::jellyfin_kodi/entrypoint/service.py:77 --->>>[ JELLYFIN ]
```