### PR TITLE
ci: update release-drafter to v7.7.0

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,20 +1,27 @@
-_extends: jellyfin/jellyfin-meta-plugins
+_extends:
+  from: jellyfin/jellyfin-meta-plugins
+  strategy:
+    categories: append
 
 name-template: "Release $RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 version-template: "$MAJOR.$MINOR.$PATCH"
 
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
+categories:
+  - type: version-resolver
+    semver-increment: major
+    when:
+      labels: [major]
+  - type: version-resolver
+    semver-increment: minor
+    when:
+      labels: [minor]
+  - type: version-resolver
+    semver-increment: patch
+    when:
+      labels: [patch]
+  - type: version-resolver
+    semver-increment: patch
 
 template: |
   ## :sparkles: What's New

--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -1,0 +1,57 @@
+###############################################################################
+# Auto Label — centralized release-drafter autolabeler
+#
+# This caller delegates to the reusable workflow maintained in
+# jellyfin/jellyfin-meta-plugins. That workflow pins the v7.7.0 autolabeler
+# action and reads the shared `autolabeler:` rules from the global config.
+# Keeping the implementation centralized prevents every Jellyfin repository
+# from independently copying security-sensitive labeling logic.
+#
+# WHY pull_request_target
+#   `pull_request` cannot label fork PRs: its token is read-only for forks,
+#   so a matching label write receives 403 and the PR remains unlabeled.
+#   `pull_request_target` runs the base repository workflow for both same-repo
+#   and fork PRs and grants the narrowly scoped pull-requests: write token.
+#
+# WHY THIS CALLER IS SAFE AS WRITTEN
+#   The workflow file is read from the base branch, not the PR. The called
+#   workflow performs API-only metadata/file matching and adds labels; it does
+#   not check out the PR, execute PR code, run shell commands, or interpolate
+#   PR-controlled strings into a shell. The caller passes the ephemeral
+#   github.token, not JF_BOT_TOKEN or another broad repository credential.
+#
+# !! DO NOT ADD STEPS, CHECKOUTS, OR SHELL COMMANDS HERE !!
+#   pull_request_target has access to repository secrets. Adding a checkout of
+#   github.event.pull_request.head.sha, a build/test command, or a run: block
+#   containing github.event.pull_request.* would turn attacker-controlled PR
+#   data/code into a privileged execution path. Keep PR builds/tests in a
+#   separate plain `pull_request` workflow with no secrets. Keep other
+#   privileged PR automation in separate minimal reusable workflows.
+#
+# The reusable workflow is pinned to a commit for supply-chain stability.
+# Update that pin only after reviewing the corresponding upstream workflow.
+###############################################################################
+
+name: Auto Label
+
+on:
+  pull_request_target:
+    branches:
+      - master
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: autolabel-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  autolabel:
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/autolabel.yaml@2d1d8651c878e11ce83de5ecdbedb31e70ebc6f0
+    with:
+      repository-name: jellyfin/jellyfin-kodi
+    secrets:
+      token: ${{ github.token }}

--- a/.github/workflows/create-prepare-release-pr.yaml
+++ b/.github/workflows/create-prepare-release-pr.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
       - name: Update Draft
-        uses: release-drafter/release-drafter@v6.4.0
+        uses: release-drafter/release-drafter@v7.7.0
         id: draft
         env:
           GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update Draft
-        uses: release-drafter/release-drafter@v6.4.0
+        uses: release-drafter/release-drafter@v7.7.0
         with:
           publish: true
         env:

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update Release Draft
-        uses: release-drafter/release-drafter@v6.4.0
+        uses: release-drafter/release-drafter@v7.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}


### PR DESCRIPTION
The upgrade of the action has the following changes

- auto labeling of PRs is now mandatory, handled through a custom action inherited from `jellyfin/jellyfin-meta-plugins`
- 2 feature deprecations (but not removal): the version-resolver and the categories labels in meta-plugins. The first one is handled by extending from `jellyfin/jellyfin-meta-plugins` and applying the `when` fields. The other is left for that repository, since we cannot modify it here.

Supersedes #1105 

Observe the massive note at the top of `.github/workflows/autolabeler.yaml`; it's left there as a warning.