### PR TITLE
Use correct key for log level

### DIFF
--- a/jellyfin_kodi/entrypoint/service.py
+++ b/jellyfin_kodi/entrypoint/service.py
@@ -424,7 +424,7 @@ class Service(xbmc.Monitor):
         if settings("logLevel") != self.settings["log_level"]:
 
             log_level = settings("logLevel")
-            self.settings["logLevel"] = log_level
+            self.settings["log_level"] = log_level
             LOG.info("New log level: %s", log_level)
 
         if settings("enableContext.bool") != self.settings["enable_context"]:


### PR DESCRIPTION
Within this file, the `log_level` key in the `settings` dictionary is used only to notify log level changes. However, the new value of the log level was being cached under the wrong key, resulting in the value deviating from the right one upon storage.

It is a fairly minor issue and would be visible only when fiddling with the log level settings repeatedly. I noticed it while working on one of my other pull requests.