### PR TITLE
Cache and reload log level

### DIFF
--- a/jellyfin_kodi/entrypoint/service.py
+++ b/jellyfin_kodi/entrypoint/service.py
@@ -424,6 +424,7 @@ class Service(xbmc.Monitor):
 
             log_level = settings("logLevel")
             self.settings["log_level"] = log_level
+            LOG.setJellyfinLevel(log_level)
             LOG.info("New log level: %s", log_level)
 
         if settings("enableContext.bool") != self.settings["enable_context"]:

--- a/jellyfin_kodi/helper/lazylogger.py
+++ b/jellyfin_kodi/helper/lazylogger.py
@@ -22,6 +22,11 @@ class LazyLogger(object):
             self.__logger = getLogger(self.__logger_name)
         return getattr(self.__logger, name)
 
+    def setJellyfinLevel(self, level):
+        from .loghandler import getHandler
+
+        getHandler().setJellyfinLevel(level)
+
     #####################################################################
     # Following are stubs of methods provided by `logging.Logger`.      #
     # Please ensure any actually functional code is above this comment. #

--- a/jellyfin_kodi/helper/loghandler.py
+++ b/jellyfin_kodi/helper/loghandler.py
@@ -28,6 +28,10 @@ def getLogger(name=None):
     return __LOGGER.getChild(name)
 
 
+def getHandler():
+    return __HANDLER
+
+
 class LogHandler(logging.StreamHandler):
 
     def __init__(self):
@@ -45,13 +49,29 @@ class LogHandler(logging.StreamHandler):
             if server.get("address"):
                 self.sensitive["Server"].append(server["address"].split("://", 1)[-1])
 
-        self.mask_info = settings("maskInfo.bool")
+        try:
+            value = settings("logLevel")
+        except RuntimeError:
+            value = "2"
+        self.setJellyfinLevel(value)
+
+        try:
+            self.mask_info = settings("maskInfo.bool")
+        except RuntimeError:
+            self.mask_info = True
 
         self.level = xbmc.LOGINFO
 
+    @classmethod
+    def setJellyfinLevel(cls, jellyfin_level):
+        try:
+            cls.jellyfin_level = int(jellyfin_level)
+        except (ValueError, TypeError):
+            cls.jellyfin_level = 2
+
     def emit(self, record):
 
-        if self._get_log_level(record.levelno):
+        if self._getLogLevel(record.levelno):
             string = self.format(record)
 
             if self.mask_info:
@@ -68,23 +88,14 @@ class LogHandler(logging.StreamHandler):
             xbmc.log(string, level=self.level)
 
     @classmethod
-    def _get_log_level(cls, level):
-
+    def _getLogLevel(cls, level):
         levels = {
             logging.ERROR: 0,
             logging.WARNING: 0,
             logging.INFO: 1,
             logging.DEBUG: 2,
         }
-        try:
-            log_level = int(settings("logLevel"))
-        except (ValueError, RuntimeError):
-            # If getting settings fail, we probably want debug logging.
-            # ValueError happens if the result is not a number
-            # RuntimeError happens if the addon is being re-installed
-            log_level = 2
-
-        return log_level >= levels[level]
+        return cls.jellyfin_level >= levels[level]
 
 
 class MyFormatter(logging.Formatter):
@@ -127,5 +138,6 @@ __LOGGER = logging.getLogger("JELLYFIN")
 for handler in __LOGGER.handlers:
     __LOGGER.removeHandler(handler)
 
-__LOGGER.addHandler(LogHandler())
+__HANDLER = LogHandler()
+__LOGGER.addHandler(__HANDLER)
 __LOGGER.setLevel(logging.DEBUG)


### PR DESCRIPTION
Cache the log level instead of retrieving it for every log record. This avoids accessing the add-on settings during teardown, when the add-on may no longer be available.

Reload the cached log level through a dedicated xbmc.Monitor in the logging module when settings change. Keeping this handling local to the logging module also avoids introducing eager imports of loghandler.

The primary advantage of caching the value is that repeated Kodi log lines of the form `error <general>: EXCEPTION: Unknown addon id 'plugin.video.jellyfin'.` are avoided during add-on teardown.

Keep information masking fixed for the lifetime of the logger and add help text indicating that changing the setting requires a Kodi restart.

Follow-up to https://github.com/jellyfin/jellyfin-kodi/pull/1185#issuecomment-5509386365

On the default Kodi skin, the help message for setting `maskInfo`  shows up in the bottom left.
<img width="1821" height="901" alt="image" src="https://github.com/user-attachments/assets/b2988bbe-94e0-4dcb-a04e-937aa3a467ac" />

