### PR TITLE
Remove unused dep script.module.addon.signals

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -44,7 +44,5 @@ dependencies:
       version: '2.22.0+matrix.1'
     - addon: 'script.module.dateutil'
       version: '2.8.1+matrix.1'
-    - addon: 'script.module.addon.signals'
-      version: '0.0.5+matrix.1'
     - addon: 'script.module.websocket'
       version: '1.6.4'

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
-setuptools >= 44.1.1  # Old setuptools causes script.module.addon.signals to fail installing
 python-dateutil >= 2.8.1
 requests >= 2.22
 PyYAML >= 6.0
@@ -7,8 +6,6 @@ backports.zoneinfo; python_version < "3.9"
 tzdata; platform_system == "Windows"
 
 Kodistubs ~=21.0
-
-git+https://github.com/ruuk/script.module.addon.signals
 
 pytest >= 4.6.11
 coverage >= 5.2


### PR DESCRIPTION
It was added in d77d619b504f4302f3139d592ec50ec48fe9fc6e with the intention of using it but an implementation that did not require it was chosen instead.

Carved out from #1188