### PR TITLE
Localize segment skip dialog

### DIFF
--- a/jellyfin_kodi/dialogs/skip.py
+++ b/jellyfin_kodi/dialogs/skip.py
@@ -3,7 +3,7 @@ from __future__ import division, absolute_import, print_function, unicode_litera
 
 import xbmcgui
 
-from ..helper import LazyLogger
+from ..helper import LazyLogger, translate
 
 LOG = LazyLogger(__name__)
 
@@ -17,13 +17,13 @@ ACTION_NAV_BACK = 92
 SKIP_BUTTON = 3012
 CLOSE_BUTTON = 3013
 
-# String IDs for segment types - using shorter labels
-SEGMENT_LABELS = {
-    "Introduction": "Intro",
-    "Credits": "Outro",
-    "Recap": "Recap",
-    "Preview": "Preview",
-    "Commercial": "Ad",
+# Localized short label IDs for known segment types
+SEGMENT_LABEL_IDS = {
+    "Introduction": 33266,
+    "Credits": 33267,
+    "Recap": 33254,
+    "Preview": 33255,
+    "Commercial": 33268,
 }
 
 
@@ -56,15 +56,18 @@ class SkipDialog(xbmcgui.WindowXMLDialog):
         minutes = int(duration // 60)
         seconds = int(duration % 60)
         if minutes > 0:
-            duration_text = "{0}m {1}s".format(minutes, seconds)
+            duration_text = translate(33264).format(minutes, seconds)
         else:
-            duration_text = "{0}s".format(seconds)
+            duration_text = translate(33265).format(seconds)
 
         # Get short segment type label
-        segment_label = SEGMENT_LABELS.get(segment_type, segment_type or "Segment")
+        segment_label_id = SEGMENT_LABEL_IDS.get(segment_type)
+        segment_label = (
+            translate(segment_label_id) if segment_label_id else translate(33269)
+        )
 
         # Set button label: "Skip Intro (1m 40s)"
-        button_label = "Skip {0} ({1})".format(segment_label, duration_text)
+        button_label = translate(33262).format(segment_label, duration_text)
 
         # Use setProperty so it's available to the skin
         self.setProperty("skip_label", button_label)

--- a/jellyfin_kodi/dialogs/skip.py
+++ b/jellyfin_kodi/dialogs/skip.py
@@ -60,11 +60,7 @@ class SkipDialog(xbmcgui.WindowXMLDialog):
         else:
             duration_text = translate(33265).format(seconds)
 
-        # Get short segment type label
-        segment_label_id = SEGMENT_LABEL_IDS.get(segment_type)
-        segment_label = (
-            translate(segment_label_id) if segment_label_id else translate(33269)
-        )
+        segment_label = translate(SEGMENT_LABEL_IDS[segment_type])
 
         # Set button label: "Skip Intro (1m 40s)"
         button_label = translate(33262).format(segment_label, duration_text)

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -13,7 +13,7 @@ from .helper import translate, api, window, settings, dialog, event, JSONRPC
 from .jellyfin import Jellyfin
 from .helper import LazyLogger
 from .helper.utils import translate_path
-from .segments import SegmentChecker
+from .segments import SegmentChecker, SEGMENT_TYPES_MAP
 
 #################################################################################################
 
@@ -533,17 +533,9 @@ class Player(xbmc.Player):
         if not response or "Items" not in response:
             return None
 
-        type_map = {
-            "Intro": "Introduction",
-            "Outro": "Credits",
-            "Recap": "Recap",
-            "Preview": "Preview",
-            "Commercial": "Commercial",
-        }
-
         segments = {}
         for item in response["Items"]:
-            seg_type = type_map.get(item.get("Type"))
+            seg_type = SEGMENT_TYPES_MAP.get(item.get("Type"))
             if seg_type:
                 segments[item.get("Id")] = {
                     "EpisodeId": item.get("ItemId"),

--- a/jellyfin_kodi/segments.py
+++ b/jellyfin_kodi/segments.py
@@ -6,6 +6,14 @@ from .helper import LazyLogger, settings
 
 LOG = LazyLogger(__name__)
 
+SEGMENT_TYPES_MAP = {
+    "Intro": "Introduction",
+    "Outro": "Credits",
+    "Recap": "Recap",
+    "Preview": "Preview",
+    "Commercial": "Commercial",
+}
+
 
 class SegmentChecker(threading.Thread):
     stop_thread = False

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1284,7 +1284,3 @@ msgstr "Outro"
 msgctxt "#33268"
 msgid "Ad"
 msgstr "Ad"
-
-msgctxt "#33269"
-msgid "Segment"
-msgstr "Segment"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1257,3 +1257,34 @@ msgctxt "#33261"
 msgid "Off"
 msgstr "Off"
 
+msgctxt "#33262"
+msgid "Skip {0} ({1})"
+msgstr "Skip {0} ({1})"
+
+msgctxt "#33263"
+msgid "Close"
+msgstr "Close"
+
+msgctxt "#33264"
+msgid "{0}m {1}s"
+msgstr "{0}m {1}s"
+
+msgctxt "#33265"
+msgid "{0}s"
+msgstr "{0}s"
+
+msgctxt "#33266"
+msgid "Intro"
+msgstr "Intro"
+
+msgctxt "#33267"
+msgid "Outro"
+msgstr "Outro"
+
+msgctxt "#33268"
+msgid "Ad"
+msgstr "Ad"
+
+msgctxt "#33269"
+msgid "Segment"
+msgstr "Segment"

--- a/resources/skins/default/1080i/script-jellyfin-skip.xml
+++ b/resources/skins/default/1080i/script-jellyfin-skip.xml
@@ -64,7 +64,7 @@
 						</control>
 						<!-- Close button -->
 						<control type="button" id="3013">
-							<label>Close</label>
+							<label>$LOCALIZE[33263]</label>
 							<height>56</height>
 							<width min="60">auto</width>
 							<font>font13</font>

--- a/tests/test_media_segments.py
+++ b/tests/test_media_segments.py
@@ -3,6 +3,9 @@ from __future__ import division, absolute_import, print_function, unicode_litera
 from unittest.mock import Mock
 
 import jellyfin_kodi.player as player_module
+from jellyfin_kodi.dialogs.skip import SEGMENT_LABEL_IDS
+from jellyfin_kodi.segments import SEGMENT_TYPES_MAP
+
 import pytest
 
 
@@ -41,6 +44,37 @@ class TestMediaSegmentsConversion:
         assert segments["id-1"]["End"] == pytest.approx(122.0)
         assert segments["id-2"]["Start"] == pytest.approx(2458.0)
         assert segments["id-2"]["End"] == pytest.approx(2520.0)
+
+    def test_convert_media_segments_drops_unknown_type_and_matches_labels(self, player):
+        response = {
+            "Items": [
+                {
+                    "Id": segment_type,
+                    "ItemId": "test-item-id",
+                    "Type": segment_type,
+                    "StartTicks": 0,
+                    "EndTicks": 10000000,
+                }
+                for segment_type in SEGMENT_TYPES_MAP
+            ]
+            + [
+                {
+                    "Id": "unknown",
+                    "ItemId": "test-item-id",
+                    "Type": "Unknown",
+                    "StartTicks": 0,
+                    "EndTicks": 10000000,
+                }
+            ]
+        }
+
+        segments = player._convert_media_segments(response)
+
+        assert set(SEGMENT_TYPES_MAP.values()) == set(SEGMENT_LABEL_IDS)
+        assert set(segment["Type"] for segment in segments.values()) == set(
+            SEGMENT_LABEL_IDS
+        )
+        assert "unknown" not in segments
 
     def test_convert_media_segments_response_allows_multiple_of_same_type(self, player):
         media_segments_response = {


### PR DESCRIPTION
Move the skip-button label, duration formatting, segment labels, and Close button text into the add-on localization resources so the dialog can be translated.