### PR TITLE
Dump running threads and their stacks on service exit

### DIFF
--- a/jellyfin_kodi/entrypoint/service.py
+++ b/jellyfin_kodi/entrypoint/service.py
@@ -6,6 +6,7 @@ import json
 import sys
 from datetime import datetime
 from importlib import reload
+import threading
 
 # Workaround for threads using datetime: _striptime is locked
 import _strptime  # noqa:F401
@@ -501,6 +502,9 @@ class Service(xbmc.Monitor):
         LOG.info("---[ objects reloaded ]")
 
     def shutdown(self):
+        LOG.debug("Running threads:")
+        for t in threading.enumerate():
+            LOG.debug("- %s: %s", t.name, t)
 
         LOG.info("---<[ EXITING ]")
         window("jellyfin_should_stop.bool", True)
@@ -533,3 +537,7 @@ class Service(xbmc.Monitor):
             self.monitor.listener.stop()
 
         LOG.info("---<<<[ JELLYFIN ]")
+
+        LOG.debug("Running threads:")
+        for t in threading.enumerate():
+            LOG.debug("- %s: %s", t.name, t)

--- a/service.py
+++ b/service.py
@@ -77,3 +77,12 @@ if __name__ == "__main__":
         break
 
     LOG.info("--<[ service ]")
+
+    import traceback
+    import sys
+
+    LOG.debug("Running threads:")
+    for t in threading.enumerate():
+        LOG.debug("- %s: %s", t.name, t)
+        if t.ident is not None:
+            LOG.debug("".join(traceback.format_stack(sys._current_frames()[t.ident])))

--- a/service.py
+++ b/service.py
@@ -82,7 +82,10 @@ if __name__ == "__main__":
     import sys
 
     LOG.debug("Running threads:")
+    frames = sys._current_frames()
     for t in threading.enumerate():
         LOG.debug("- %s: %s", t.name, t)
         if t.ident is not None:
-            LOG.debug("".join(traceback.format_stack(sys._current_frames()[t.ident])))
+            stack = frames.get(t.ident)
+            if stack is not None:
+                LOG.debug("".join(traceback.format_stack(stack)))


### PR DESCRIPTION
There have been several issues regarding Kodi hanging on exit.

This PR adds some more logging that hopefully sheds some light on what is going on in the background when this happens.

