### PR TITLE
Fix audio stream selection after playback starts

### DIFF
--- a/jellyfin_kodi/helper/playutils.py
+++ b/jellyfin_kodi/helper/playutils.py
@@ -47,6 +47,7 @@ def set_properties(item, method, server_id=None):
             "PlaySessionId": info.get("PlaySessionId", str(uuid4()).replace("-", "")),
             "ServerId": server_id,
             "DeviceId": client.get_device_id(),
+            "KodiAudioStreamIndexes": info.get("KodiAudioStreamIndexes"),
             "SubsMapping": info.get("Subtitles"),
             "AudioStreamIndex": info.get("AudioStreamIndex"),
             "SubtitleStreamIndex": info.get("SubtitleStreamIndex"),
@@ -179,6 +180,12 @@ class PlayUtils(object):
         prop: jellyfinfilename for ?? I thought it was to pass the real path to subtitle add-ons but it's not working?
         """
         self.info["MediaSourceId"] = source["Id"]
+        # Map Kodi's audio stream ordinal to the Jellyfin media stream index.
+        self.info["KodiAudioStreamIndexes"] = [
+            stream["Index"]
+            for stream in source.get("MediaStreams", [])
+            if stream["Type"] == "Audio"
+        ]
 
         if source.get("RequiresClosing"):
 

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -106,6 +106,8 @@ class Player(xbmc.Player):
         window("jellyfin_play.json", items)
 
         self.set_item(current_file, item)
+        requested_audio = item["AudioStreamIndex"]
+        requested_subtitle = item["SubtitleStreamIndex"]
         # Detect current audio/subtitle state from Kodi player
         self.detect_audio_subs(item)
         data = {
@@ -141,7 +143,7 @@ class Player(xbmc.Player):
             return
 
         if item["PlayOption"] == "Addon":
-            self.set_audio_subs(item["AudioStreamIndex"], item["SubtitleStreamIndex"])
+            self.set_audio_subs(requested_audio, requested_subtitle)
 
     def set_item(self, file, item):
         """Set playback information."""
@@ -188,7 +190,7 @@ class Player(xbmc.Player):
         LOG.info("-->[ play/%s ] %s", item["Id"], item)
 
     def set_audio_subs(self, audio=None, subtitle=None):
-        if audio:
+        if audio is not None:
             audio = int(audio)
         if subtitle:
             subtitle = int(subtitle)
@@ -202,9 +204,14 @@ class Player(xbmc.Player):
 
             item = self.get_file_info(current_file)
             mapping = item["SubsMapping"]
+            kodi_audio_stream_indexes = item.get("KodiAudioStreamIndexes") or []
 
-            if audio and len(self.getAvailableAudioStreams()) > 1:
-                self.setAudioStream(audio - 1)
+            if (
+                audio is not None
+                and len(self.getAvailableAudioStreams()) > 1
+                and audio in kodi_audio_stream_indexes
+            ):
+                self.setAudioStream(kodi_audio_stream_indexes.index(audio))
 
             if subtitle is None or subtitle == -1:
                 self.showSubtitles(False)
@@ -237,7 +244,7 @@ class Player(xbmc.Player):
         try:  # Audio tracks
             audio = result["currentaudiostream"]["index"]
         except (KeyError, TypeError):
-            audio = 0
+            audio = None
 
         try:  # Subtitles tracks
             subs = result["currentsubtitle"]["index"]
@@ -249,7 +256,12 @@ class Player(xbmc.Player):
         except (KeyError, TypeError):
             subs_enabled = False
 
-        item["AudioStreamIndex"] = audio + 1
+        kodi_audio_stream_indexes = item.get("KodiAudioStreamIndexes") or []
+        item["AudioStreamIndex"] = (
+            kodi_audio_stream_indexes[audio]
+            if audio is not None and 0 <= audio < len(kodi_audio_stream_indexes)
+            else None
+        )
 
         if not subs_enabled or not len(self.getAvailableSubtitleStreams()):
             item["SubtitleStreamIndex"] = None

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -257,11 +257,9 @@ class Player(xbmc.Player):
             subs_enabled = False
 
         kodi_audio_stream_indexes = item.get("KodiAudioStreamIndexes") or []
-        item["AudioStreamIndex"] = (
-            kodi_audio_stream_indexes[audio]
-            if audio is not None and 0 <= audio < len(kodi_audio_stream_indexes)
-            else None
-        )
+        item["AudioStreamIndex"] = None
+        if audio is not None and 0 <= audio < len(kodi_audio_stream_indexes):
+            item["AudioStreamIndex"] = kodi_audio_stream_indexes[audio]
 
         if not subs_enabled or not len(self.getAvailableSubtitleStreams()):
             item["SubtitleStreamIndex"] = None

--- a/jellyfin_kodi/player.py
+++ b/jellyfin_kodi/player.py
@@ -106,8 +106,6 @@ class Player(xbmc.Player):
         window("jellyfin_play.json", items)
 
         self.set_item(current_file, item)
-        requested_audio = item["AudioStreamIndex"]
-        requested_subtitle = item["SubtitleStreamIndex"]
         # Detect current audio/subtitle state from Kodi player
         self.detect_audio_subs(item)
         data = {
@@ -143,7 +141,7 @@ class Player(xbmc.Player):
             return
 
         if item["PlayOption"] == "Addon":
-            self.set_audio_subs(requested_audio, requested_subtitle)
+            self.set_audio_subs(item["AudioStreamIndex"], item["SubtitleStreamIndex"])
 
     def set_item(self, file, item):
         """Set playback information."""
@@ -256,8 +254,10 @@ class Player(xbmc.Player):
         except (KeyError, TypeError):
             subs_enabled = False
 
+        # When playback is started, the audiostream is not available
+        # In such a case, audio is None and we must not overwrite the
+        # item level value
         kodi_audio_stream_indexes = item.get("KodiAudioStreamIndexes") or []
-        item["AudioStreamIndex"] = None
         if audio is not None and 0 <= audio < len(kodi_audio_stream_indexes):
             item["AudioStreamIndex"] = kodi_audio_stream_indexes[audio]
 

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -7,9 +7,8 @@ from jellyfin_kodi.helper import playutils as playutils_module
 def test_audio_stream_indexes_are_stored_for_playback(monkeypatch):
     # Validate that KodiAudioStreamIndexes is set, given the
     # Audio streams in the source file
-    class ApiClient:
-        class config:
-            data = {"auth.token": ""}
+    api_client = Mock()
+    api_client.config.data = {"auth.token": ""}
 
     item = {
         "Id": "item",
@@ -42,19 +41,24 @@ def test_audio_stream_indexes_are_stored_for_playback(monkeypatch):
 
     monkeypatch.setattr(playutils_module, "window", fake_window)
     monkeypatch.setattr(playutils_module.client, "get_device_id", lambda: "device")
+
+    class Api:
+        def get_file_path(self, _):
+            return "movie"
+
     monkeypatch.setattr(
         playutils_module.api,
         "API",
-        lambda *_args, **_kwargs: Mock(get_file_path=Mock(return_value="movie")),
+        lambda *_args, **_kwargs: Api(),
     )
 
     play_utils = playutils_module.PlayUtils(
         item,
         server="http://server",
-        api_client=ApiClient,
+        api_client=api_client,
     )
     play_utils.info["Path"] = "movie"
-    play_utils.direct_url = Mock()
+    play_utils.direct_url = lambda _source: None
 
     play_utils.get(source)
     playutils_module.set_properties(item, "DirectStream", "server")
@@ -64,17 +68,15 @@ def test_audio_stream_indexes_are_stored_for_playback(monkeypatch):
 
 
 def test_detect_audio_stream_maps_kodi_ordinal_to_jellyfin_index(monkeypatch):
-    # Verify that the Kodi audio ordinal that is currently set
-    # maps back correctly to the AudioStreamIndex on the server
-    # This is used in report_playback to detect which audio
-    # is currently playing
+    # Kodi reports audio stream ordinals
+    # Jellyfin uses MediaStream indexes.
     player = object.__new__(player_module.Player)
     item = {
         "KodiAudioStreamIndexes": [3, 4],
         "SubsMapping": {},
     }
 
-    class JsonRpc:
+    class JSONRPC:
         def __init__(self, _):
             pass
 
@@ -87,7 +89,7 @@ def test_detect_audio_stream_maps_kodi_ordinal_to_jellyfin_index(monkeypatch):
                 }
             }
 
-    monkeypatch.setattr(player_module, "JSONRPC", JsonRpc)
+    monkeypatch.setattr(player_module, "JSONRPC", JSONRPC)
 
     player.detect_audio_subs(item)
 
@@ -95,8 +97,8 @@ def test_detect_audio_stream_maps_kodi_ordinal_to_jellyfin_index(monkeypatch):
 
 
 def test_set_audio_stream_maps_jellyfin_index_to_kodi_ordinal():
-    # Verify that calling set_audio_subs with a Jellyfin
-    # index maps to the correct Kodi ordinal
+    # Jellyfin uses MediaStream indexes
+    # Kodi expects audio ordinals.
     player = object.__new__(player_module.Player)
     item = {
         "KodiAudioStreamIndexes": [3, 4],
@@ -108,7 +110,6 @@ def test_set_audio_stream_maps_jellyfin_index_to_kodi_ordinal():
     player.is_playing_file = lambda _: True
     player.getAvailableAudioStreams = lambda: [{}, {}]
     player.setAudioStream = Mock()
-    player.showSubtitles = Mock()
 
     player.set_audio_subs(audio=4)
 
@@ -116,9 +117,9 @@ def test_set_audio_stream_maps_jellyfin_index_to_kodi_ordinal():
 
 
 def test_playback_started_preserves_requested_audio_stream(monkeypatch):
-    # Assert that starting playback does not set the
-    # requested Jellyfin server audio index to None or
-    # even 0
+    # Kodi may not report the current audio stream
+    # immediately after playback starts. Preserve
+    # the requested stream while detecting it.
     player = object.__new__(player_module.Player)
 
     server = Mock()
@@ -152,7 +153,7 @@ def test_playback_started_preserves_requested_audio_stream(monkeypatch):
     monkeypatch.setattr(player_module.xbmc, "Monitor", Mock(return_value=monitor))
     monkeypatch.setattr(player_module, "settings", Mock(return_value=False))
 
-    class JsonRpc:
+    class JSONRPC:
         def __init__(self, _):
             pass
 
@@ -165,7 +166,7 @@ def test_playback_started_preserves_requested_audio_stream(monkeypatch):
                 }
             }
 
-    monkeypatch.setattr(player_module, "JSONRPC", JsonRpc)
+    monkeypatch.setattr(player_module, "JSONRPC", JSONRPC)
 
     def fake_window(name, value=None, **kwargs):
         if name == "jellyfin_play.json" and value is None:

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -176,5 +176,5 @@ def test_playback_started_preserves_requested_audio_stream(monkeypatch):
 
     player.onPlayBackStarted()
 
-    assert item["AudioStreamIndex"] is None
+    assert item["AudioStreamIndex"] == 4
     player.set_audio_subs.assert_called_once_with(4, None)

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,0 +1,179 @@
+from unittest.mock import Mock
+
+import jellyfin_kodi.player as player_module
+from jellyfin_kodi.helper import playutils as playutils_module
+
+
+def test_audio_stream_indexes_are_stored_for_playback(monkeypatch):
+    # Validate that KodiAudioStreamIndexes is set, given the
+    # Audio streams in the source file
+    class ApiClient:
+        class config:
+            data = {"auth.token": ""}
+
+    item = {
+        "Id": "item",
+        "Type": "Movie",
+        "MediaType": "Video",
+    }
+    source = {
+        "Id": "source",
+        "Path": "movie",
+        "SupportsDirectPlay": False,
+        "SupportsDirectStream": True,
+        "MediaStreams": [
+            {"Index": 0, "Type": "Subtitle"},
+            {"Index": 1, "Type": "Subtitle"},
+            {"Index": 2, "Type": "Video"},
+            {"Index": 3, "Type": "Audio"},
+            {"Index": 4, "Type": "Audio"},
+        ],
+        "DefaultAudioStreamIndex": 4,
+        "DefaultSubtitleStreamIndex": None,
+    }
+
+    windows = {}
+
+    def fake_window(name, value=None, **kwargs):
+        if name == "jellyfin_play.json":
+            if value is None:
+                return windows.get(name)
+            windows[name] = value
+
+    monkeypatch.setattr(playutils_module, "window", fake_window)
+    monkeypatch.setattr(playutils_module.client, "get_device_id", lambda: "device")
+    monkeypatch.setattr(
+        playutils_module.api,
+        "API",
+        lambda *_args, **_kwargs: Mock(get_file_path=Mock(return_value="movie")),
+    )
+
+    play_utils = playutils_module.PlayUtils(
+        item,
+        server="http://server",
+        api_client=ApiClient,
+    )
+    play_utils.info["Path"] = "movie"
+    play_utils.direct_url = Mock()
+
+    play_utils.get(source)
+    playutils_module.set_properties(item, "DirectStream", "server")
+
+    playback_item = windows["jellyfin_play.json"][0]
+    assert playback_item["KodiAudioStreamIndexes"] == [3, 4]
+
+
+def test_detect_audio_stream_maps_kodi_ordinal_to_jellyfin_index(monkeypatch):
+    # Verify that the Kodi audio ordinal that is currently set
+    # maps back correctly to the AudioStreamIndex on the server
+    # This is used in report_playback to detect which audio
+    # is currently playing
+    player = object.__new__(player_module.Player)
+    item = {
+        "KodiAudioStreamIndexes": [3, 4],
+        "SubsMapping": {},
+    }
+
+    class JsonRpc:
+        def __init__(self, _):
+            pass
+
+        def execute(self, _):
+            return {
+                "result": {
+                    "currentaudiostream": {"index": 1},
+                    "currentsubtitle": {},
+                    "subtitleenabled": False,
+                }
+            }
+
+    monkeypatch.setattr(player_module, "JSONRPC", JsonRpc)
+
+    player.detect_audio_subs(item)
+
+    assert item["AudioStreamIndex"] == 4
+
+
+def test_set_audio_stream_maps_jellyfin_index_to_kodi_ordinal():
+    # Verify that calling set_audio_subs with a Jellyfin
+    # index maps to the correct Kodi ordinal
+    player = object.__new__(player_module.Player)
+    item = {
+        "KodiAudioStreamIndexes": [3, 4],
+        "SubsMapping": {},
+    }
+
+    player.get_playing_file = lambda: "movie"
+    player.get_file_info = lambda _: item
+    player.is_playing_file = lambda _: True
+    player.getAvailableAudioStreams = lambda: [{}, {}]
+    player.setAudioStream = Mock()
+    player.showSubtitles = Mock()
+
+    player.set_audio_subs(audio=4)
+
+    player.setAudioStream.assert_called_once_with(1)
+
+
+def test_playback_started_preserves_requested_audio_stream(monkeypatch):
+    # Assert that starting playback does not set the
+    # requested Jellyfin server audio index to None or
+    # even 0
+    player = object.__new__(player_module.Player)
+
+    server = Mock()
+    item = {
+        "Id": "item",
+        "Path": "movie",
+        "PlayOption": "Addon",
+        "KodiAudioStreamIndexes": [3, 4],
+        "SubsMapping": {},
+        "AudioStreamIndex": 4,
+        "SubtitleStreamIndex": None,
+        "MediaSourceId": "source",
+        "PlayMethod": "DirectPlay",
+        "Volume": 100,
+        "CurrentPosition": 0,
+        "Paused": False,
+        "Muted": False,
+        "PlaySessionId": "session",
+        "Server": server,
+    }
+
+    player.stop_playback = Mock()
+    player._reset_state = Mock()
+    player.getPlayingFile = Mock(return_value="movie")
+    player.set_item = Mock()
+    player.set_audio_subs = Mock()
+    player.getAvailableSubtitleStreams = lambda: []
+
+    monitor = Mock()
+    monitor.waitForAbort.return_value = False
+    monkeypatch.setattr(player_module.xbmc, "Monitor", Mock(return_value=monitor))
+    monkeypatch.setattr(player_module, "settings", Mock(return_value=False))
+
+    class JsonRpc:
+        def __init__(self, _):
+            pass
+
+        def execute(self, _):
+            return {
+                "result": {
+                    "currentaudiostream": {},
+                    "currentsubtitle": {},
+                    "subtitleenabled": True,
+                }
+            }
+
+    monkeypatch.setattr(player_module, "JSONRPC", JsonRpc)
+
+    def fake_window(name, value=None, **kwargs):
+        if name == "jellyfin_play.json" and value is None:
+            return [item]
+
+    monkeypatch.setattr(player_module, "window", fake_window)
+
+    player.onPlayBackStarted()
+
+    assert item["AudioStreamIndex"] is None
+    player.set_audio_subs.assert_called_once_with(4, None)

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -174,6 +174,7 @@ def test_playback_started_preserves_requested_audio_stream(monkeypatch):
     def fake_window(name, value=None, **kwargs):
         if name == "jellyfin_play.json" and value is None:
             return [item]
+        return None
 
     monkeypatch.setattr(player_module, "window", fake_window)
 

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -38,6 +38,9 @@ def test_audio_stream_indexes_are_stored_for_playback(monkeypatch):
             if value is None:
                 return windows.get(name)
             windows[name] = value
+            return None
+        else:
+            return None
 
     monkeypatch.setattr(playutils_module, "window", fake_window)
     monkeypatch.setattr(playutils_module.client, "get_device_id", lambda: "device")
@@ -63,7 +66,7 @@ def test_audio_stream_indexes_are_stored_for_playback(monkeypatch):
     play_utils.get(source)
     playutils_module.set_properties(item, "DirectStream", "server")
 
-    playback_item = windows["jellyfin_play.json"][0]
+    playback_item = fake_window("jellyfin_play.json")[0]
     assert playback_item["KodiAudioStreamIndexes"] == [3, 4]
 
 


### PR DESCRIPTION
This change fixes 2 closely related but distinct issues:
1. The false assumption that there is an arithmetic mapping between the server's media stream indexes and that of Kodi.
2. When playback starts, audio streams are not immediately available. If the current audio stream is fetched and not found, it gets overwritten with the 0th Kodi ordinal.

The fixes are:
1. Map Jellyfin audio stream indexes to Kodi stream ordinals instead of assuming the Jellyfin index corresponds to the Kodi stream position.
2. If Kodi responds with no available audio streams, do not overwrite the preferred media stream index in the item dictionary.

The test cases verify that:
1. The mapping is stored in the window
3. The look-up from Kodi ordinal to Jellyfin server index is detected
   correctly in `report_playback`
4. Given a request from the server to use a specific index, the mapping
   to the Kodi ordinal is accurately determined and used
5. Starting playback does not cause a loss of the requested Jellyfin
   server index and corresponding replacement with 0 or None

Fixes #1203

Reproduced with a DirectPlay MKV containing two external subtitles followed by video and two audio streams. Jellyfin selected English (`MediaStream.Index == 4`), while Kodi initially returned an empty `currentaudiostream`.

Before the change, the missing audio stream was treated as Kodi audio ordinal 0, overwriting the requested stream and resulting in Japanese audio. After the change, the unavailable stream is represented as `None`, the requested Jellyfin index 4 is preserved, and the `[3, 4]` audio-index mapping translates it to Kodi ordinal 1. Kodi subsequently reports ordinal 1 with language `en`.

Another good way to handle these would be to carve out `onAVStarted` separately; however, that is a bigger architectural change which will require a lot more testing to be certain.